### PR TITLE
fix: resolve 10 post-merge bugs blocking playable game

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,6 +80,7 @@
     "superpowers@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "supabase@claude-plugins-official": true,
-    "github@claude-plugins-official": true
+    "github@claude-plugins-official": true,
+    "vercel@claude-plugins-official": true
   }
 }

--- a/app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts
+++ b/app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts
@@ -20,6 +20,50 @@ const ACTOR_COLORS: Record<string, string> = {
   china:        '#de2910',
 }
 
+async function fillFromCapabilities(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  scenarioId: string,
+  assets: MapAsset[]
+): Promise<void> {
+  const { data: caps } = await supabase
+    .from('actor_capabilities')
+    .select('id, actor_id, name, asset_type, category, lat, lng, status, description')
+    .eq('scenario_id', scenarioId)
+    .not('lat', 'is', null)
+    .not('lng', 'is', null)
+
+  if (!caps) return
+
+  const typeMap: Record<string, string> = {
+    nuclear_facility: 'nuclear_facility', oil_gas_facility: 'oil_gas_facility',
+    military_base: 'military_base', carrier: 'carrier_group',
+    carrier_group: 'carrier_group', naval_base: 'naval_asset',
+    airbase: 'military_base', headquarters: 'military_base',
+    missile_battery: 'missile_battery',
+  }
+
+  for (const cap of caps as Array<{
+    id: string; actor_id: string; name: string; asset_type: string | null
+    category: string | null; lat: number; lng: number; status: string | null
+    description: string | null
+  }>) {
+    const rawType = cap.asset_type ?? cap.category ?? 'military_base'
+    assets.push({
+      id:                      cap.id,
+      actor_id:                cap.actor_id,
+      asset_type:              (typeMap[rawType] ?? 'military_base') as MapAssetType,
+      label:                   cap.name,
+      lat:                     cap.lat,
+      lng:                     cap.lng,
+      status:                  cap.status === 'destroyed' ? 'destroyed' : cap.status === 'degraded' ? 'degraded' : 'operational',
+      capacity_pct:            100,
+      actor_color:             ACTOR_COLORS[cap.actor_id] ?? '#888888',
+      tooltip:                 cap.description ?? cap.name,
+      is_approximate_location: rawType === 'carrier' || rawType === 'carrier_group',
+    })
+  }
+}
+
 function facilityTypeToMapAssetType(type: string): MapAssetType {
   const map: Record<string, MapAssetType> = {
     nuclear_facility:  'nuclear_facility',
@@ -45,89 +89,77 @@ export async function GET(
   const { searchParams } = new URL(request.url)
   const turnCommitId = searchParams.get('turnCommitId')
 
-  if (!turnCommitId) {
-    return NextResponse.json({ error: 'turnCommitId is required' }, { status: 400 })
-  }
-
   try {
-    const state = await getStateAtTurn(params.branchId, turnCommitId)
+    const supabase = await createClient()
+    const assets: MapAsset[] = []
 
-    const assets: MapAsset[] = state.facility_statuses
-      .filter(f => f.lat !== undefined && f.lng !== undefined)
-      .map(f => ({
-        id:                      `${f.actor_id}-${f.name.toLowerCase().replace(/\s+/g, '-')}`,
-        actor_id:                f.actor_id,
-        asset_type:              facilityTypeToMapAssetType(f.type),
-        label:                   f.name,
-        lat:                     f.lat!,
-        lng:                     f.lng!,
-        status:                  f.status,
-        capacity_pct:            f.capacity_pct,
-        actor_color:             ACTOR_COLORS[f.actor_id] ?? '#888888',
-        tooltip:                 `${f.name} — ${f.status} (${f.capacity_pct}% capacity). ${f.location_label}`,
-        is_approximate_location: f.type === 'carrier_group' || f.type === 'troop_deployment',
-      }))
+    if (turnCommitId) {
+      // Prefer state-engine data when we have a commit reference
+      const state = await getStateAtTurn(params.branchId, turnCommitId)
 
-    // Fallback: if facility_statuses had no coordinates, query actor_capabilities directly
-    if (assets.length === 0) {
-      const supabase = await createClient()
-      const { data: caps } = await supabase
-        .from('actor_capabilities')
-        .select('id, actor_id, name, asset_type, category, lat, lng, status, description')
-        .eq('scenario_id', state.scenario_id)
-        .not('lat', 'is', null)
-        .not('lng', 'is', null)
+      const stateAssets: MapAsset[] = state.facility_statuses
+        .filter(f => f.lat !== undefined && f.lng !== undefined)
+        .map(f => ({
+          id:                      `${f.actor_id}-${f.name.toLowerCase().replace(/\s+/g, '-')}`,
+          actor_id:                f.actor_id,
+          asset_type:              facilityTypeToMapAssetType(f.type),
+          label:                   f.name,
+          lat:                     f.lat!,
+          lng:                     f.lng!,
+          status:                  f.status,
+          capacity_pct:            f.capacity_pct,
+          actor_color:             ACTOR_COLORS[f.actor_id] ?? '#888888',
+          tooltip:                 `${f.name} — ${f.status} (${f.capacity_pct}% capacity). ${f.location_label}`,
+          is_approximate_location: f.type === 'carrier_group' || f.type === 'troop_deployment',
+        }))
 
-      if (caps) {
-        for (const cap of caps as Array<{
-          id: string; actor_id: string; name: string; asset_type: string | null
-          category: string | null; lat: number; lng: number; status: string | null
-          description: string | null
-        }>) {
-          const typeMap: Record<string, string> = {
-            nuclear_facility: 'nuclear_facility', oil_gas_facility: 'oil_gas_facility',
-            military_base: 'military_base', carrier: 'carrier_group',
-            carrier_group: 'carrier_group', naval_base: 'naval_asset',
-            airbase: 'military_base', headquarters: 'military_base',
-            missile_battery: 'missile_battery',
-          }
-          const rawType = cap.asset_type ?? cap.category ?? 'military_base'
-          assets.push({
-            id: cap.id,
-            actor_id: cap.actor_id,
-            asset_type: (typeMap[rawType] ?? 'military_base') as MapAssetType,
-            label: cap.name,
-            lat: cap.lat,
-            lng: cap.lng,
-            status: cap.status === 'destroyed' ? 'destroyed' : cap.status === 'degraded' ? 'degraded' : 'operational',
-            capacity_pct: 100,
-            actor_color: ACTOR_COLORS[cap.actor_id] ?? '#888888',
-            tooltip: cap.description ?? cap.name,
-            is_approximate_location: rawType === 'carrier' || rawType === 'carrier_group',
-          })
-        }
+      assets.push(...stateAssets)
+
+      // Fallback within the turnCommitId path: if facility_statuses had no coordinates
+      if (assets.length === 0) {
+        await fillFromCapabilities(supabase, params.id, assets)
       }
+
+      const shipping_lanes: ShippingLane[] = [
+        {
+          id:             'strait_of_hormuz',
+          label:          'Strait of Hormuz',
+          throughput_pct: state.global_state.hormuz_throughput_pct,
+          coordinates:    HORMUZ_COORDINATES,
+        },
+      ]
+
+      const response: MapAssetsResponse = {
+        turn_commit_id: turnCommitId,
+        as_of_date:     state.as_of_date,
+        assets,
+        shipping_lanes,
+      }
+      return NextResponse.json({ data: response })
     }
+
+    // No turnCommitId — return static capability snapshot
+    await fillFromCapabilities(supabase, params.id, assets)
 
     const shipping_lanes: ShippingLane[] = [
       {
         id:             'strait_of_hormuz',
         label:          'Strait of Hormuz',
-        throughput_pct: state.global_state.hormuz_throughput_pct,
+        throughput_pct: 100,
         coordinates:    HORMUZ_COORDINATES,
       },
     ]
 
     const response: MapAssetsResponse = {
-      turn_commit_id: turnCommitId,
-      as_of_date:     state.as_of_date,
+      turn_commit_id: '',
+      as_of_date:     new Date().toISOString().split('T')[0],
       assets,
       shipping_lanes,
     }
-
     return NextResponse.json({ data: response })
+
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error'
-    return NextResponse.json({ error: message }, { status: 500 })
+    console.error('[map-assets] Error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,9 @@ export const metadata: Metadata = {
   title: "GeoSim — Strategic Simulation Engine",
   description:
     "AI-powered strategic simulation engine modeling competitive dynamics between actors through interactive decision-making and branching scenario trees.",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/app/scenarios/[id]/page.tsx
+++ b/app/scenarios/[id]/page.tsx
@@ -328,7 +328,7 @@ export default function ScenarioHubPage({ params }: { params: { id: string } }) 
           .order('created_at', { ascending: true }),
         supabase
           .from('actors')
-          .select('id, name, country_code')
+          .select('actor_id, name')
           .eq('scenario_id', params.id),
       ])
       if (branchRes.data && branchRes.data.length > 0) {
@@ -339,9 +339,9 @@ export default function ScenarioHubPage({ params }: { params: { id: string } }) 
       if (actorRes.data) {
         setActorOptions(
           actorRes.data.map((a: Record<string, unknown>) => ({
-            id: a.id as string,
+            id: a.actor_id as string,
             name: a.name as string,
-            flag: ((a.country_code as string | null) ?? (a.name as string).slice(0, 3)).toUpperCase(),
+            flag: (a.name as string).slice(0, 3).toUpperCase(),
           }))
         )
       }
@@ -376,7 +376,7 @@ export default function ScenarioHubPage({ params }: { params: { id: string } }) 
           return
         }
       }
-      setBranchError('Branch creation is not available yet.')
+      setBranchError('Branching is available from the Play page after selecting a turn.')
     } catch {
       setBranchError('Failed to create branch — please try again.')
     } finally {

--- a/app/scenarios/[id]/play/[branchId]/page.tsx
+++ b/app/scenarios/[id]/play/[branchId]/page.tsx
@@ -45,7 +45,7 @@ export default async function PlayPage({ params }: Props) {
   const { data: actorRows } = await supabase
     .from('actors')
     .select('actor_id, name, win_condition, lose_condition, strategic_posture, escalation_ladder')
-    .eq('scenario_id', params.id)
+    .eq('scenario_id', scenario?.id ?? params.id)
 
   // 4. Fetch current state via state engine
   let currentState = null
@@ -61,7 +61,7 @@ export default async function PlayPage({ params }: Props) {
   const { data: commits } = await supabase
     .from('turn_commits')
     .select('turn_number, simulated_date, narrative_entry')
-    .eq('branch_id', params.branchId)
+    .eq('branch_id', branch?.id ?? params.branchId)
     .order('turn_number', { ascending: true })
 
   // 6. Fetch ground truth branch
@@ -77,6 +77,14 @@ export default async function PlayPage({ params }: Props) {
     .select('id, turn_number, simulated_date, narrative_entry')
     .eq('branch_id', trunkBranch?.id ?? params.branchId)
     .order('turn_number', { ascending: true })
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[play page] params:', { id: params.id, branchId: params.branchId })
+    console.log('[play page] scenario?.id:', scenario?.id)
+    console.log('[play page] branch?.id:', branch?.id)
+    console.log('[play page] actorRows?.length:', actorRows?.length ?? 0)
+    console.log('[play page] commits?.length:', commits?.length ?? 0)
+  }
 
   // --- Transform DB rows → GameInitialData types ---
 

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,85 +2,85 @@
 Updated by Claude Code at the end of each session.
 
 ## Current sprint: Sprint 3 — Real Data + AI Pipeline
-## Last session: 2026-04-08
+## Last session: 2026-04-11
 
 ### Completed (this session)
-- **Merged PR #48** (feat/iran-seed-comprehensive → main) via squash merge
-- **Live State Engine — PR #49 open** (feat/live-state-engine, all 9 tasks complete, 179/179 tests passing)
-  - Task 1: Live State Engine types added to lib/types/simulation.ts
-    (BranchStateAtTurn, LiveActorState, ThresholdTrigger, ThresholdResult, FacilityStatus,
-     LiveGlobalState, ActorPanelResponse, MapAssetsResponse, etc.)
-  - Task 2: lib/game/state-engine.ts — pure functions (daysBetween, computeAssetAvailability,
-    applyDepletion, applyEventEffects) — 25 tests
-  - Task 3: lib/game/state-engine.ts — async DB functions (getStateAtTurn, forkStateForBranch,
-    persistStateSnapshot) — mocked Supabase tests
-  - Task 4: lib/game/threshold-evaluator.ts — evaluateThresholds, resolveVariablePath,
-    sustained-days evaluation, armed-only query, DB writes on fire — 7 tests
-  - Task 5: lib/ai/actor-agent.ts — buildStateContextBlock (formats live actor state for AI
-    prompts with AVAILABLE/CONSTRAINED/EXHAUSTED asset labels) — 6 tests
-  - Task 6: app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts — returns
-    geo-coded facilities + shipping lanes for Mapbox — 6 tests
-  - Task 7: app/api/scenarios/[id]/branches/[branchId]/actor-panel/[actorId]/route.ts —
-    returns live scores, grouped asset inventory, depletion forecast — 7 tests
-  - Task 8: lib/game/game-loop.ts — onGroundTruthAdvanced, onPlayerDecision, onBranchCreated
-    integration points
-  - Task 9: Pushed branch, opened PR #49
-- **Vercel build fixes** (all on feat/live-state-engine):
-  - Double-cast LiveGlobalState and LiveActorState in threshold-evaluator.ts to satisfy tsc
-  - Replaced Bun.main with process.argv[1] in all 9 scripts/* files
-  - Replaced Bun.spawn with spawnSync (child_process) in scripts/update-ground-truth.ts
-- **Phase A–D status audit** (explore agent):
-  - Phase A: ALL DONE (#53 seed, #54 fog-of-war, #55 decision-prerequisites, #56 state-updates)
-  - Phase B: #57 DONE (buildStateContextBlock), #58 MISSING (resolution engine + API route)
-  - Phase C: #61 PARTIAL (TurnPlan builder display only), #62–#64 DONE (chronicle, actor panel, Mapbox)
-  - Phase D: #65 PARTIAL (auth pages exist + dev bypass), #66 MISSING (no .github/workflows/)
+- **Playable game bug fixes — PR #59 open** (fix/playable-game-bugs, closes #51 + #57)
+  - 10 of 11 bugs fixed; Bug 10 (z-index panel overlap, P2) deferred for browser inspection
+  - 502/502 tests passing, 0 typecheck errors, 0 lint errors
+  - Bug 1: Fixed actors query in scenario hub — `actor_id` not `id`, removed `country_code`
+  - Bug 2: Removed hardcoded `/api/scenarios/iran-2026/cities` fetch from GameMap.tsx
+  - Bug 3: Made `turnCommitId` optional in map-assets route — fallback to `actor_capabilities`
+  - Bug 4: Fixed GameMap response parsing — `{ data }` not `{ assets }` (was reading wrong level)
+  - Bug 5: Removed `<ResearchUpdatePanel>` from GameView — admin-only tool, no permission check
+  - Bug 6: Fixed TopBar hardcoded `turnNumber=4, totalTurns=12` defaults → 0/0 with dash display
+  - Bug 7: Actors query in play page now uses `scenario?.id ?? params.id` (UUID vs slug fix)
+  - Bug 8: Chronicle query now uses `branch?.id ?? params.branchId` (same UUID fix)
+  - Bug 9: Decisions tab and DecisionCatalog hidden when `isGtMode` (observer/trunk mode)
+  - Bug 11: Branch creation error message improved to explain it's available from Play page
+  - Issue #57: Added `public/favicon.svg` and metadata to resolve 404
+  - Excluded `tests/e2e/**` from Vitest to prevent Playwright type conflicts
+- **Wrote bug fix implementation plan** — `docs/superpowers/plans/2026-04-09-playable-game-bug-fixes.md`
+- **Updated docs/scrum-issues.md** — marked completed issues, added GH↔scrum number map, added 5-plan sprint summary
+- **Added GitHub issues #51-#58** for remaining work items
 
 ### Open PRs
-- PR #49: feat/live-state-engine — Live State Engine (ready for review, Vercel build in progress)
+- PR #59: fix/playable-game-bugs — 10 bug fixes (ready for review, closes #51 + #57)
 
 ### In progress
-- Vercel build on PR #49 — fixing scripts/* Bun globals, may need one more build check
+- Nothing — PR #59 is the only open work item
 
 ### Next up (in priority order)
-1. **#66 CI/CD** — GitHub Actions with Vitest + typecheck + lint; closes the Vercel feedback loop
-2. **#58 Resolution engine** — lib/ai/resolution-engine.ts + app/api/branches/[branchId]/resolve/route.ts
-   — THE critical blocker for a playable turn; requires actor agent to emit TurnPlan first
-3. **#57 Actor agent (TurnPlan generation)** — app/api/ai/actor/route.ts needs full TurnPlan output;
-   buildStateContextBlock exists but TurnPlan generation and the route are missing
-4. **#61 TurnPlan builder UI** — DispatchTerminal is read-only display; need interactive decision submission
-
-### GitHub issue map (current open)
-- #49: PR — Live State Engine
-- #53: Iran scenario Supabase seed (DONE — seed script + 4MB enriched dataset)
-- #54: Fog of war (DONE)
-- #55: Decision prerequisites (DONE)
-- #56: State updates (DONE)
-- #57: Actor agent — PARTIAL (buildStateContextBlock done; TurnPlan API route missing)
-- #58: Resolution engine — MISSING
-- #59–#61: Game logic / player interaction — most game logic DONE, TurnPlan UI PARTIAL
-- #62: Chronicle — DONE
-- #63: Actor detail panel — DONE
-- #64: Mapbox real impl — DONE (655 lines, real Mapbox GL)
-- #65: Auth — PARTIAL (pages + dev bypass; real auth not enforced)
-- #66: CI/CD — MISSING
+1. **Merge PR #59** — review and merge the playable game bug fixes
+2. **Plan 2: Research Pipeline (Issue #31)** — 7-stage Iran scenario research pipeline
+   - `lib/ai/research-pipeline.ts`, `app/api/scenarios/[id]/research/route.ts`
+3. **Plan 3: AI Pipeline Core (Issues #32, #33, #52)**
+   - #52: Multi-actor decision catalog (decisions for all 6 actors, not just US)
+   - #32: Actor agent full TurnPlan generation (buildStateContextBlock exists, route missing)
+   - #33: Resolution engine (processes all actor TurnPlans simultaneously)
+4. **Plan 4: Judge + Narrator (Issues #34, #35)**
+5. **Plan 5: Game Loop + Player Interaction (Issues #36, #37, #38, #53, #54)**
+6. **Quick tasks: #40 (auth middleware), #41 (CI/CD)**
 
 ### Known bugs / debt
+- Bug 10: Actor status panel overlaps map layer toggles — P2, CSS z-index issue, needs browser inspection
 - getConstraintCascadeRisk (lib/game/escalation.ts) uses Iran-specific keyword matching
   instead of reading from Scenario.constraintCascades — tracked for future sprint
 - scripts/update-ground-truth.ts: Bun.spawn replaced with spawnSync — blocking call,
   fine for CLI use but would need async refactor if ever called from server context
+- actors tab and chronicle: root cause of empty data (UUID vs slug) is patched with fallback,
+  but underlying data consistency should be verified in Supabase (do actors have UUID scenario_id
+  or slug scenario_id?)
+
+### GitHub issue map (current open)
+- #59: PR — Playable game bug fixes (fix/playable-game-bugs)
+- #31: Research pipeline — OPEN
+- #32: Actor agent full TurnPlan — OPEN (partial: buildStateContextBlock done)
+- #33: Resolution engine — OPEN
+- #34: Judge agent — OPEN
+- #35: Narrator — OPEN
+- #36: Game loop controller — OPEN
+- #37: Turn submission — OPEN (partial: advance route + useSubmitTurn exist)
+- #38: Branch creation — OPEN
+- #40: Auth — OPEN (partial: pages + dev bypass)
+- #41: CI/CD — OPEN
+- #51: Playable game bugs — OPEN (PR #59 in review)
+- #52: Multi-actor decision catalog — OPEN
+- #53: Observer mode full implementation — OPEN
+- #54: Actor dossier data quality — OPEN
+- #55: Seed data quality pass — OPEN
+- #56: Error boundaries + blank state — OPEN
+- #57: Favicon — OPEN (PR #59 in review)
+- #58: Rate limiting + AI cost controls — OPEN
 
 ### Architecture decisions (this session)
-- BranchStateAtTurn includes initial_inventories: Record<string, Record<string, number>>
-  (not in spec) — needed so applyDepletion can recompute asset_availability without
-  additional DB calls; populated by getStateAtTurn from actor_capabilities table
-- ActorPanelAssetGroup named to avoid collision with existing AssetCategory union type
-- ThresholdResult.forced_event typed as Record<string, unknown> | null — correct because
-  it's constructed from jsonb forced_event_template (schema defined per scenario, not at compile time)
-- Double cast (as unknown as T) required for LiveGlobalState/LiveActorState index access
-  — TypeScript strict mode doesn't allow direct cast without index signature
-- process.argv[1] === new URL(import.meta.url).pathname replaces Bun.main guard
-  — identical semantics, works without @types/bun
+- map-assets route: when `turnCommitId` absent, use `params.id` (scenario ID) for
+  `actor_capabilities` query; return `turn_commit_id: ''` as sentinel for static snapshot
+- `fillFromCapabilities` extracted as named helper to avoid duplication between the two
+  code paths (with/without turnCommitId)
+- GameMap response parsing: route returns `{ data: MapAssetsResponse }` envelope;
+  client must destructure `{ data }` then access `data.assets`
+- Vitest excludes `tests/e2e/**` — Playwright specs cause type conflicts in Vitest runner
 
 ### Architecture decisions (previous sessions)
 - Using bun (not npm/npx) for all package management — npm/npx are Windows binaries in WSL2
@@ -93,3 +93,10 @@ Updated by Claude Code at the end of each session.
 - Inline style objects: put border shorthand BEFORE borderBottom, not after (shorthand overwrites specific)
 - Frontend validation workflow: geosim-playwright skill → geosim-uiux-validation skill → user approves all 4 CATs → commit
 - Supabase Realtime .subscribe() callback must be typed as (status: string, err?: Error) — implicit any breaks Vercel build
+- BranchStateAtTurn includes initial_inventories: Record<string, Record<string, number>>
+  (not in spec) — needed so applyDepletion can recompute asset_availability without
+  additional DB calls; populated by getStateAtTurn from actor_capabilities table
+- Double cast (as unknown as T) required for LiveGlobalState/LiveActorState index access
+  — TypeScript strict mode doesn't allow direct cast without index signature
+- process.argv[1] === new URL(import.meta.url).pathname replaces Bun.main guard
+  — identical semantics, works without @types/bun

--- a/components/game/GameView.tsx
+++ b/components/game/GameView.tsx
@@ -15,7 +15,6 @@ import { ChronicleTimeline } from '@/components/chronicle/ChronicleTimeline'
 import { EventsTab } from '@/components/panels/EventsTab'
 import { ActorControlSelector } from '@/components/game/ActorControlSelector'
 import { DispatchTerminal } from '@/components/game/DispatchTerminal'
-import { ResearchUpdatePanel } from '@/components/game/ResearchUpdatePanel'
 import { ObserverOverlay } from '@/components/panels/ObserverOverlay'
 import { TurnPhaseIndicator } from '@/components/game/TurnPhaseIndicator'
 import { ProgressBar } from '@/components/ui/ProgressBar'
@@ -357,7 +356,7 @@ export function GameView({ branchId, scenarioId, initialData }: Props) {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, ease: 'easeOut' }}
           >
-            {PANEL_TABS.map(({ id, label }) => (
+            {PANEL_TABS.filter(t => !isGtMode || t.id !== 'decisions').map(({ id, label }) => (
               <button
                 key={id}
                 onClick={() => setActiveTab(id)}
@@ -382,7 +381,7 @@ export function GameView({ branchId, scenarioId, initialData }: Props) {
                 onSelect={(id) => dispatch({ type: 'SELECT_ACTOR', payload: id })}
               />
             )}
-            {activeTab === 'decisions' && (
+            {activeTab === 'decisions' && !isGtMode && (
               <DecisionCatalog
                 decisions={initialData.decisions}
                 onSelect={handleDecisionSelect}
@@ -428,11 +427,6 @@ export function GameView({ branchId, scenarioId, initialData }: Props) {
           {/* Dispatch terminal footer — initial state lines */}
           <div className="shrink-0 overflow-hidden" style={{ height: '120px' }}>
             <DispatchTerminal lines={dispatchLines} isRunning={false} />
-          </div>
-
-          {/* Ground truth research panel */}
-          <div className="shrink-0 p-3 border-t border-border-subtle">
-            <ResearchUpdatePanel scenarioId={scenarioId} />
           </div>
         </>
       )}

--- a/components/map/GameMap.tsx
+++ b/components/map/GameMap.tsx
@@ -59,7 +59,6 @@ export function GameMap({ globalState, scenarioId = 'iran-2026', branchId = '', 
   const [selectedAsset, setSelectedAsset] = useState<PositionedAsset | null>(null)
   const [popupAsset, setPopupAsset] = useState<PositionedAsset | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
-  const [cities, setCities] = useState<City[]>([])
   const [selectedCity, setSelectedCity] = useState<City | null>(null)
   const [cityPopup, setCityPopup] = useState<City | null>(null)
   const [cityDetailOpen, setCityDetailOpen] = useState(false)
@@ -71,16 +70,11 @@ export function GameMap({ globalState, scenarioId = 'iran-2026', branchId = '', 
     const url = `/api/scenarios/${scenarioId}/branches/${branchId}/map-assets${turnCommitId ? `?turnCommitId=${turnCommitId}` : ''}`
     fetch(url)
       .then(r => r.json())
-      .then(({ assets: data }: { assets: MapAsset[] | null }) => { if (data) setMapAssets(data) })
+      .then(({ data }: { data: { assets: MapAsset[] } | null }) => {
+        if (data?.assets) setMapAssets(data.assets)
+      })
       .catch(() => {})
   }, [scenarioId, branchId, turnCommitId])
-
-  useEffect(() => {
-    fetch('/api/scenarios/iran-2026/cities')
-      .then(r => r.json())
-      .then(({ data }: { data: City[] | null }) => { if (data) setCities(data) })
-      .catch(() => {})
-  }, [])
 
   function handleAssetClick(asset: PositionedAsset) {
     setPopupAsset(asset)
@@ -133,7 +127,6 @@ export function GameMap({ globalState, scenarioId = 'iran-2026', branchId = '', 
             assets={assets}
             selectedAssetId={selectedAsset?.id ?? null}
             onAssetClick={handleAssetClick}
-            cities={cities}
             onCityClick={handleCityClick}
           />
           {popupAsset && (

--- a/components/ui/TopBar.tsx
+++ b/components/ui/TopBar.tsx
@@ -21,8 +21,8 @@ function toPhase(raw: string): Phase {
 export function TopBar({
   scenarioName = "Iran Conflict Scenario",
   scenarioHref,
-  turnNumber = 4,
-  totalTurns = 12,
+  turnNumber = 0,
+  totalTurns = 0,
   phase = "Planning",
   gameMode = "Simulation",
 }: TopBarProps) {
@@ -63,8 +63,9 @@ export function TopBar({
       {/* Right side: turn counter + phase badge */}
       <div className="ml-auto flex items-center gap-3">
         <span className="font-mono text-xs text-text-tertiary">
-          TURN {String(turnNumber).padStart(2, "0")} /{" "}
-          {String(totalTurns).padStart(2, "0")}
+          {turnNumber > 0 || totalTurns > 0
+            ? `TURN ${String(turnNumber).padStart(2, '0')} / ${String(totalTurns).padStart(2, '0')}`
+            : 'TURN — / —'}
         </span>
         <span className="px-2 py-0.5 font-mono text-2xs bg-gold-dim rounded-none border border-gold-border tracking-[0.03em] uppercase">
           <TurnPhaseIndicator phase={toPhase(phase)} />

--- a/docs/bugs/2026-04-09-playable-game-bugs.md
+++ b/docs/bugs/2026-04-09-playable-game-bugs.md
@@ -1,0 +1,129 @@
+# Playable Game Bug Report
+**Date:** 2026-04-09  
+**Branch investigated:** main (after PR #50 merge)  
+**Reporter:** Claude Code  
+
+---
+
+## Bug 1 — Actors query uses wrong column names → 400 error
+
+**File:** `app/scenarios/[id]/page.tsx` lines ~326–344  
+**Symptom:** `zaaewkegrmbqgsojlfum.supabase.co/rest/v1/actors?select=id%2Cname%2Ccountry_code` → 400; branch tree shows "Loading branches…" forever  
+**Root cause:** The Supabase query selects `id, name, country_code` from the `actors` table. The actors table has no `id` column (primary key is `actor_id`) and no `country_code` column. Supabase returns 400 on invalid column names. The flag emoji in the actor option list also tries to use `country_code` as a key to look up flags.  
+**Why it breaks the branch tree:** The `useEffect` in this component runs both the branches query AND the actors query. When the actors query fails, the error is swallowed silently, but `actorOptions` stays empty. The `setBranchRoot` call may still fire if branches succeed, but the overall component is in a degraded state.  
+**Fix:** Change query to `.select('actor_id, name')` and use `actor_id` (not `country_code`) as the key into `FLAG_MAP`.
+
+---
+
+## Bug 2 — `GameMap` still calls hardcoded `/api/scenarios/iran-2026/cities` → 500
+
+**File:** `components/map/GameMap.tsx` line ~79  
+**Symptom:** `GET /api/scenarios/iran-2026/cities 500 (Internal Server Error)` in devtools  
+**Root cause:** The old `/cities` fetch was never removed during Task 6. It still uses the hardcoded `iran-2026` scenario ID regardless of the `scenarioId` prop, and it points to a route (`/api/scenarios/[id]/cities`) that either doesn't exist or throws. Even if fixed to use `scenarioId`, key cities are already hardcoded as static GeoJSON in `MapboxMap.tsx` — this fetch is entirely redundant.  
+**Fix:** Delete the cities fetch call entirely. Cities are already handled statically in `MapboxMap.tsx`.
+
+---
+
+## Bug 3 — `map-assets` route requires `turnCommitId` and returns 400 when missing
+
+**File:** `app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts` lines ~46–50  
+**Symptom:** `GET /api/scenarios/iran-2026/branches/trunk/map-assets 400 (Bad Request)` — also triggered when `turnCommitId` query param is absent or empty  
+**Root cause:** The route calls `getStateAtTurn(branchId, turnCommitId)` and returns 400 if `turnCommitId` is not provided. On first load of the ground truth branch, `GameMap` may not yet have the `turnCommitId` from `initialData`, or the prop isn't being passed. The URL also shows `trunk` as the branchId in some older call paths — `trunk` is not a valid branch UUID.  
+**Secondary cause:** `GameMap.tsx` has `branchId = ''` as a default prop, so when rendered before `initialData` is available, `branchId` is empty and the fetch constructs an invalid URL like `/api/scenarios/iran-2026/branches//map-assets`.  
+**Fix:**  
+1. Make `turnCommitId` optional in the map-assets route — if absent, skip `getStateAtTurn` and go directly to the `actor_capabilities` fallback (which always has coordinates).  
+2. In `GameMap.tsx`, don't fetch when `branchId` is empty or falsy.  
+3. Ensure `initialData.branch.headCommitId` is passed as `turnCommitId` from `GameView` → `GameMap`.
+
+---
+
+## Bug 4 — Map only shows USS Nimitz (placed on land) and Strait of Hormuz
+
+**File:** `components/map/GameMap.tsx` and `app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts`  
+**Symptom:** Only one ship marker visible (USS Nimitz), positioned on land; no other military assets  
+**Root cause:** Because of Bug 3 (400 on map-assets), the `actor_capabilities` fallback never executes. The single asset showing is likely a hardcoded default in `MapboxMap.tsx`, not a real DB result. The Nimitz being on land suggests a lat/lng value of approximately (36°N, 54°E) which is central Iran — the coordinates in the seed data may have lat/lng swapped for some assets.  
+**Fix:** Fix Bug 3 first (make `turnCommitId` optional → fallback to `actor_capabilities`). Then audit the `actor_capabilities` seed data to confirm lat/lng values are correct (not swapped).
+
+---
+
+## Bug 5 — "Run Research Update" button visible in game UI
+
+**File:** `components/game/ResearchUpdatePanel.tsx` line ~80  
+**Symptom:** A "Run Research Update" button appears in the bottom-right of the game view, accessible to all users  
+**Root cause:** `ResearchUpdatePanel` is an admin/developer tool (triggers a 7-stage AI research pipeline). It has no permission check — it renders unconditionally wherever it's included in the game layout.  
+**Fix:** Either (a) remove `<ResearchUpdatePanel />` from `GameView.tsx` entirely (research updates are a backend admin operation), or (b) gate it behind `process.env.NEXT_PUBLIC_DEV_MODE === 'true'`. Option (a) is cleaner.
+
+---
+
+## Bug 6 — TopBar shows "Turn 4/12" hardcoded defaults
+
+**File:** `components/ui/TopBar.tsx` lines ~24–25  
+**Symptom:** Turn counter shows "4/12" instead of real values  
+**Root cause:** TopBar has hardcoded default props `turnNumber = 4` and `totalTurns = 12`. The play page does pass real values, but if `gtCommits.length === 0` (ground truth commits not loaded) or `turnNumber === 0`, the defaults kick in. The real fix is twofold: remove the hardcoded defaults from TopBar, AND ensure the play page correctly computes `turnNumber` from `initialData`.  
+**Why data may be missing:** If the branch record has no `head_commit_id` (e.g., ground truth branch seeded without a head pointer), `turnNumber` falls back to 0. Also `gtCommits.length` is 0 if `turn_commits` for the trunk branch returns empty.  
+**Fix:** Remove hardcoded defaults from TopBar (`turnNumber = 0`, `totalTurns = 0`). Also verify the ground truth branch has a populated `head_commit_id` in Supabase and that `turn_commits` rows exist for it.
+
+---
+
+## Bug 7 — Actors tab is blank in GameView
+
+**File:** `components/game/GameView.tsx` and `app/scenarios/[id]/play/[branchId]/page.tsx`  
+**Symptom:** Right-side actors panel shows nothing  
+**Root cause:** `initialData.actors` is empty. The play page fetches actors with `.eq('scenario_id', params.id)` where `params.id` is the scenario UUID (e.g., the UUID for the Iran scenario). However, if the `scenarios` table row for Iran uses a slug (`iran-2026`) as its ID but the URL parameter is a UUID, the query returns empty. Alternatively, if the actors table rows have a different `scenario_id` format than what's in the URL, they won't match.  
+**Fix:** Verify that the `scenario_id` stored in the `actors` table matches the `id` format used in the URL (UUID vs slug). If the scenario is accessed by slug `iran-2026`, the actors' `scenario_id` must also be `iran-2026`. Log what `params.id` is on the server and what the actors query returns.
+
+---
+
+## Bug 8 — Chronicle/events tab is empty
+
+**File:** `app/scenarios/[id]/play/[branchId]/page.tsx`  
+**Symptom:** No events shown in the chronicle panel  
+**Root cause:** Same as Bug 7 — `turn_commits` are queried with `.eq('branch_id', params.branchId)`. If `params.branchId` doesn't match any `branch_id` in `turn_commits`, the query returns empty. Also possible: the ground truth branch has commits seeded but `branch_id` in `turn_commits` doesn't match the branch UUID in the URL.  
+**Fix:** Verify that the `branchId` in the URL (from the BranchTree navigation) matches the `branch_id` in `turn_commits` rows. Add a server-side log or error fallback to surface when queries return empty unexpectedly.
+
+---
+
+## Bug 9 — Decisions panel shows US-only decisions in observer mode
+
+**File:** `components/game/GameView.tsx`  
+**Symptom:** Decision panel shows decisions even in observer mode, and only shows US-perspective options  
+**Root cause:** The decisions passed from `initialData.decisions` come from `IRAN_DECISIONS` in `lib/game/iran-decisions.ts`, which is a US-centric decision catalog (all 7 options are US strategic choices). In observer mode (`isTrunk = true`), the decisions panel should either be hidden entirely or show a read-only multi-actor view. Currently `isGtMode` is computed but not used to hide the decisions panel.  
+**Fix:**  
+1. In `GameView.tsx`, wrap the DecisionPanel/TurnPlanBuilder in `{!isGtMode && ...}` so it's hidden in observer mode.  
+2. Long-term: replace the static US-only `IRAN_DECISIONS` with a multi-actor catalog or derive available decisions from the selected actor.
+
+---
+
+## Bug 10 — Actor status panel overlaps map layer toggles
+
+**File:** `components/game/GameView.tsx` or `components/panels/ActorStatusPanel.tsx`  
+**Symptom:** The actor status panel (left side) renders on top of the map layer toggle buttons  
+**Root cause:** CSS z-index or absolute positioning conflict. The map layer toggle component uses absolute positioning and the actor panel likely has an overlapping stacking context.  
+**Fix:** Audit z-index values and positioning of both components. The map layer toggles should have a higher z-index than any floating panels, or the panel should be moved to not overlap the toggle position.
+
+---
+
+## Bug 11 — "Branch creation is not available yet" placeholder text
+
+**File:** `components/scenario/BranchTree.tsx` (likely)  
+**Symptom:** Button or message says "Branch creation is not available yet"  
+**Root cause:** Placeholder UI for a feature not yet implemented. This is expected — branch creation (forking from a ground truth node) was explicitly deferred to the next sprint.  
+**Fix:** Either hide this UI element entirely for now, or change the text to be less jarring ("Branching available in Player Mode").
+
+---
+
+## Priority Order for Fixes
+
+| Priority | Bug | Impact |
+|----------|-----|--------|
+| P0 | Bug 3 — map-assets 400 / make turnCommitId optional | Blocks all map assets |
+| P0 | Bug 1 — actors query wrong columns | Breaks scenario browser |
+| P0 | Bug 2 — hardcoded /cities call | Console error, 500 |
+| P0 | Bug 7 — actors empty in play page | Blank actors tab |
+| P0 | Bug 8 — chronicle empty | No game history visible |
+| P1 | Bug 4 — map assets don't render | Core feature broken |
+| P1 | Bug 5 — Research Update button | Admin tool exposed |
+| P1 | Bug 9 — Decisions in observer mode | Wrong UI mode |
+| P2 | Bug 6 — TopBar hardcoded defaults | Visual clutter |
+| P2 | Bug 10 — Panel overlap | Layout issue |
+| P3 | Bug 11 — Branch creation placeholder | Minor UX |

--- a/docs/scrum-issues.md
+++ b/docs/scrum-issues.md
@@ -322,5 +322,45 @@ Independent (can start any time):
 | #39      | #64     | Mapbox real impl | ✅ CLOSED |
 | #40      | #65     | Auth | 🔲 OPEN (partial) |
 | #41      | #66     | CI/CD | 🔲 OPEN |
-| new      | —       | Playable game bug fixes (11 bugs) | 🔲 CREATE |
+| #51      | —       | Playable game bug fixes (11 bugs) | 🔲 OPEN |
+| #52      | —       | Multi-actor decision catalog | 🔲 OPEN |
+| #53      | —       | Observer mode full implementation | 🔲 OPEN |
+| #54      | —       | Actor dossier data quality | 🔲 OPEN |
+| #55      | —       | Seed data quality pass | 🔲 OPEN |
+| #56      | —       | Error boundaries + blank state handling | 🔲 OPEN |
+| #57      | —       | Favicon | 🔲 OPEN |
+| #58      | —       | Rate limiting + AI cost controls | 🔲 OPEN |
 | new      | —       | Live State Engine | ✅ DONE — PR #49 (no GH issue existed) |
+
+---
+
+## Sprint Planning — Implementation Plans
+
+The remaining open issues group into **5 implementation plans** plus 2 quick tasks:
+
+### Plan 1 — Bug Fixes (Issue #51)
+**Issues:** #51 + #55 (seed data quality), #56 (error boundaries), #57 (favicon)
+**Branch:** `fix/playable-game-bugs`
+**Description:** Fix all 11 post-merge bugs blocking the playable game. Root causes are wrong DB column names, hardcoded URLs, missing API fallbacks, and wrong CSS z-index. No AI involved. One focused pass.
+
+### Plan 2 — Research Pipeline (Issue #31)
+**Issues:** #31
+**Description:** Implement the 7-stage Iran scenario research pipeline per `docs/research-pipeline.md`. Self-contained — feeds enriched context into actor agents.
+
+### Plan 3 — AI Pipeline Core (Issues #32, #33, #52)
+**Issues:** #32 (actor agent full TurnPlan), #33 (resolution engine), #52 (multi-actor decision catalog)
+**Description:** Actor agents generate TurnPlans from their decision catalog → resolution engine processes all actors' plans simultaneously → produces `EventStateEffects`. Tightly coupled: actor output feeds directly into resolution.
+**Blocker:** #52 (multi-actor decision catalog) must be done first or alongside.
+
+### Plan 4 — Judge + Narrator (Issues #34, #35)
+**Issues:** #34 (judge evaluator), #35 (narrator)
+**Description:** Evaluator-optimizer pair. Judge scores resolution output (0–100); if below threshold, resolution retries. Narrator converts final resolution into `ChronicleEntry` narrative. Always work together.
+
+### Plan 5 — Game Loop + Player Interaction (Issues #36, #37, #38, #53, #54)
+**Issues:** #36 (game loop orchestration), #37 (full turn submission), #38 (branch creation), #53 (observer mode), #54 (actor dossier)
+**Description:** Orchestration layer wires Plans 3+4 into a complete turn. Advance route calls game loop → streams SSE → narrator writes chronicle. Also covers player-facing UI improvements: observer mode view and actor dossier quality.
+
+### Quick Tasks (no /plan needed)
+- **#40** — Auth: middleware update only (~2 hours)
+- **#41** — CI/CD: single `.github/workflows/ci.yml` file (~1 hour)
+- **#58** — Rate limiting: add after AI loop is working (cost controls without working loop are premature)

--- a/docs/scrum-issues.md
+++ b/docs/scrum-issues.md
@@ -1,7 +1,8 @@
 # GeoSim Scrum Workflow & GitHub Issues
 
-> Last updated: 2026-03-27. Sprint 2 Stitch frontend migration complete.
+> Last updated: 2026-04-09. Sprint 3 real-data wiring complete. Bug fixes in progress.
 > Target state: Full playable game with Iran scenario AI turns.
+> Note: scrum doc uses projected issue numbers (#52–#66). Actual GitHub issue numbers are #27–#41.
 
 ---
 
@@ -31,111 +32,66 @@ Components built:
 - Scenario Hub page (`/scenarios/[id]`) with ActorCard, tab switching
 - Scenario Browser page (`/scenarios`) with category filter
 
+### Sprint 3 — Real Data + AI Pipeline (in progress)
+
+**Issue #27 (scrum #52): Iran scenario Supabase seed ✅ DONE**
+- PR #48 merged — comprehensive Iran seed pipeline (actors, branches, turn_commits, actor_capabilities, actor_state_snapshots)
+- 4MB enriched dataset, scripts/seed-iran-scenario.ts complete
+
+**Issue #28 (scrum #53): Replace frontend mock data with Supabase queries ✅ DONE**
+- PR #50 merged — async RSC play page, GameInitialData type, GameView wired to real data
+- Bugs catalogued in docs/bugs/2026-04-09-playable-game-bugs.md (11 bugs, fix in progress)
+
+**Issue #29 (scrum #54): Landing page ✅ DONE**
+- Closed with PR #29/animations work
+
+**Issue #30 (scrum #55): Animations pass ✅ DONE**
+- Closed with Sprint 2 / PR #30
+
+**Issue #39 (scrum #64): Mapbox GL — real implementation ✅ DONE**
+- PR #46 (Sprint 3 asset layer) — 655 lines, real Mapbox GL, 30 positioned military assets,
+  12 cities, actor status layer, AssetInfoPanel click-to-inspect (PR #50)
+
+**Live State Engine ✅ DONE** (no scrum issue — added retroactively)
+- PR #49 merged — lib/game/state-engine.ts, lib/game/threshold-evaluator.ts,
+  lib/ai/actor-agent.ts (buildStateContextBlock), map-assets route, actor-panel route,
+  lib/game/game-loop.ts integration points
+- 179/179 tests passing
+
+**Issues #10, #11, #12: App layout, UI components, Mapbox shell ✅ DONE**
+- All completed during Sprint 2 Stitch migration — GitHub issues should be closed
+
 ---
 
 ## Remaining Work — Ordered by Dependency
 
-### PHASE A: Foundation for Real Data
+### IMMEDIATE: Bug Fixes (new — 2026-04-09)
 
-**Issue #52: Iran scenario Supabase seed**
-Title: `feat: Seed Iran conflict 2025-2026 scenario into Supabase`
-Labels: `P0-critical`, `backend`
+**GH issue to create: Playable game bug fixes**
+Title: `fix: Resolve 11 post-merge bugs blocking playable game`
+Labels: `P0-critical`, `bug`, `frontend`, `backend`
+See: `docs/bugs/2026-04-09-playable-game-bugs.md`
 
-Seed all Iran scenario data into Supabase so the frontend can drop mock data.
-
-Files:
-- Create: `scripts/seed-iran-scenario.ts`
-- Create: `supabase/seed.sql`
-
-Data to seed:
-- `scenarios`: id='iran-2026', name='US-Israel-Iran Conflict 2025-2026', status='active', turn_number=4
-- `actors`: united_states, iran, israel, russia, china, gulf_states (state JSON matching `lib/types/simulation.ts`)
-- `branches`: id='trunk', scenario_id='iran-2026'
-- `scenario_commits`: turns 1–4 matching MOCK_CHRONICLE_ENTRIES in GameView.tsx
-- `decisions`: 7 decisions matching MOCK_DECISIONS in GameView.tsx
-
-Acceptance criteria:
-- [ ] `bun run seed` populates all tables without error
-- [ ] All 6 actors exist with correct escalation rungs (US:5, Iran:6, Israel:6, Russia:1, China:1, Gulf:2)
-- [ ] Branch 'trunk' exists at turn 4
+Bugs:
+- Bug 1: `app/scenarios/[id]/page.tsx` actors query uses wrong column names (`id`, `country_code`) → 400
+- Bug 2: `GameMap.tsx` still calls hardcoded `/api/scenarios/iran-2026/cities` → 500
+- Bug 3: map-assets route returns 400 when `turnCommitId` missing (should fall back to actor_capabilities)
+- Bug 4: Map shows only USS Nimitz (on land) — caused by Bug 3
+- Bug 5: "Run Research Update" admin button exposed to all users
+- Bug 6: TopBar hardcoded defaults `turnNumber=4, totalTurns=12`
+- Bug 7: Actors tab blank in GameView (actors query mismatch)
+- Bug 8: Chronicle empty (turn_commits query mismatch)
+- Bug 9: Decisions panel visible in observer mode, US-only
+- Bug 10: Actor status panel overlaps map layer toggles (CSS z-index)
+- Bug 11: "Branch creation is not available yet" placeholder text visible
 
 ---
 
-**Issue #53: Wire scenario hub and play view to real Supabase data**
-Title: `feat: Replace frontend mock data with Supabase queries`
-Labels: `P0-critical`, `frontend`
-Depends on: #52
+### PHASE B: AI Pipeline (depends on real data being stable)
 
-Replace MOCK_* constants in GameView.tsx and scenario hub with real Supabase queries.
-
-Files:
-- Modify: `app/scenarios/[id]/page.tsx` (fetch real actors from Supabase)
-- Modify: `app/scenarios/[id]/play/[branchId]/page.tsx` (fetch branch + snapshot)
-- Modify: `components/game/GameView.tsx` (remove mock data, receive props)
-- Create: `lib/queries/scenario.ts` (reusable server-side query functions)
-
-Acceptance criteria:
-- [ ] Scenario hub shows real actors from Supabase
-- [ ] Chronicle timeline shows real events from scenario_commits
-- [ ] Play view loads correct branch data
-- [ ] Mock data constants removed from components
-
----
-
-**Issue #54: Landing page**
-Title: `feat: Landing page with product explanation and CTA`
-Labels: `P1-important`, `frontend`
-
-Replace the current design-system showcase home page with a real landing page.
-Current `app/page.tsx` is a component demo — visitors have no idea what GeoSim is.
-
-Per `docs/frontend-design.md` "Declassified War Room" concept:
-- Hero: classified document aesthetic, dramatic framing of the Iran conflict
-- Value prop: "AI-powered strategic simulation" — what it is, who it's for
-- Single CTA: "Enter the Simulation" → /scenarios
-- Stats: "6 actors, 14 decisions, AI resolution engine"
-
-Files:
-- Modify: `app/page.tsx` (full rewrite as landing page, remove component showcase)
-
-Acceptance criteria:
-- [ ] Visitor understands what GeoSim is without scrolling
-- [ ] Single clear CTA navigates to /scenarios
-- [ ] Passes `geosim-uiux-validation` skill (all 4 categories)
-
----
-
-**Issue #55: Animations pass**
-Title: `feat: Add entrance animations and premium motion to all pages`
-Labels: `P0-critical`, `frontend`
-
-The app looks good statically but feels dead. Add intentional motion.
-
-Required animations:
-- `app/page.tsx`: hero content fades in on load
-- `app/scenarios/page.tsx`: scenario cards stagger-fade on mount
-- `app/scenarios/[id]/page.tsx`: actor cards stagger-fade on tab switch
-- `components/chronicle/TurnEntry.tsx`: entries slide in from left on mount
-- `components/chronicle/GlobalTicker.tsx`: continuous auto-scroll (CSS marquee or JS)
-- `components/panels/ActorDetailPanel.tsx`: slide from right (if not already)
-- `components/game/DispatchTerminal.tsx`: new lines animate in
-- All buttons: `active:scale-[0.97]` press state
-- `components/panels/DecisionCatalog.tsx`: hover reveals DimensionTag with fade
-
-Acceptance criteria:
-- [ ] All listed animations implemented
-- [ ] Nothing feels abrupt or cheap
-- [ ] Animations don't delay interactions (< 300ms entries, instant clicks)
-- [ ] Passes `geosim-uiux-validation` CAT 2 (animations) with user approval
-
----
-
-### PHASE B: AI Pipeline (can work in parallel with Phase A)
-
-**Issue #56: Research pipeline API**
+**Issue #31 (scrum #56): Iran scenario research pipeline — all 7 stages**
 Title: `feat: Iran scenario research pipeline — all 7 stages`
 Labels: `P0-critical`, `ai-pipeline`, `backend`
-Depends on: #52
 
 Implement the 7-stage research pipeline per `docs/research-pipeline.md`.
 
@@ -153,14 +109,16 @@ Acceptance criteria:
 
 ---
 
-**Issue #57: Actor agent with prompt caching**
-Title: `feat: Actor agent — turn plan generation with prompt caching`
+**Issue #32 (scrum #57): Actor agent with prompt caching**
+Title: `feat: Actor agent — full TurnPlan generation with prompt caching`
 Labels: `P0-critical`, `ai-pipeline`, `backend`
-Depends on: #56
+Depends on: #31 (research pipeline)
+
+Status: `buildStateContextBlock` done (PR #49). Full TurnPlan generation route missing.
 
 Files:
 - Modify: `app/api/ai/actor/route.ts`
-- Create: `lib/ai/actor-agent.ts`
+- Modify: `lib/ai/actor-agent.ts` (add TurnPlan generation from context block)
 - Create: `lib/ai/prompts/actor.ts`
 - Create: `tests/api/actor-agent.test.ts`
 
@@ -172,27 +130,27 @@ Acceptance criteria:
 
 ---
 
-**Issue #58: Resolution engine**
+**Issue #33 (scrum #58): Resolution engine**
 Title: `feat: Resolution engine — process all actor TurnPlans into outcomes`
 Labels: `P0-critical`, `ai-pipeline`, `backend`
-Depends on: #57
+Depends on: #32
 
 Files:
-- Modify: `app/api/branches/[branchId]/resolve/route.ts`
+- Create: `app/api/scenarios/[id]/branches/[branchId]/resolve/route.ts`
 - Create: `lib/ai/resolution-engine.ts`
 - Create: `tests/api/resolution-engine.test.ts`
 
 Acceptance criteria:
 - [ ] All actor plans processed together
-- [ ] Outputs EventImpact objects matching `lib/types/simulation.ts`
-- [ ] `applyEventImpact` from `lib/game/state-updates.ts` applied to scenario state
+- [ ] Outputs EventStateEffects matching `lib/types/simulation.ts`
+- [ ] `onPlayerDecision` from `lib/game/game-loop.ts` called with resolved effects
 
 ---
 
-**Issue #59: Judge evaluator with retry loop**
+**Issue #34 (scrum #59): Judge evaluator with retry loop**
 Title: `feat: Judge agent — evaluate resolution quality with retry`
 Labels: `P0-critical`, `ai-pipeline`, `backend`
-Depends on: #58
+Depends on: #33
 
 Evaluator-optimizer pattern. Score < 60 → retry. Max 3 retries.
 
@@ -204,14 +162,14 @@ Files:
 Acceptance criteria:
 - [ ] Judge returns score 0–100 with dimension breakdown
 - [ ] Resolution retries if score < 60 (max 3 attempts)
-- [ ] Judge scores stored in scenario_commits table
+- [ ] Judge scores stored in turn_commits table
 
 ---
 
-**Issue #60: Narrator — chronicle writer**
+**Issue #35 (scrum #60): Narrator — chronicle writer**
 Title: `feat: Narrator agent — generate chronicle entries from resolution`
 Labels: `P1-important`, `ai-pipeline`, `backend`
-Depends on: #59
+Depends on: #34
 
 Files:
 - Modify: `app/api/ai/narrator/route.ts`
@@ -219,101 +177,83 @@ Files:
 - Create: `tests/api/narrator.test.ts`
 
 Acceptance criteria:
-- [ ] Narrator produces EntryData JSON (turnNumber, date, title, narrative, severity, tags)
-- [ ] Output stored as scenario_commit with chronicle_entry field
+- [ ] Narrator produces ChronicleEntry JSON (turnNumber, date, title, narrative, severity, tags)
+- [ ] Output stored as turn_commit with narrative_entry field
 - [ ] Severity chosen by AI based on event magnitude
 
 ---
 
-**Issue #61: Game loop controller — full turn**
+**Issue #36 (scrum #61): Game loop controller — full turn**
 Title: `feat: Game loop controller — orchestrate full turn end-to-end`
 Labels: `P0-critical`, `ai-pipeline`, `backend`
-Depends on: #57, #58, #59, #60
+Depends on: #32, #33, #34, #35
 
 Orchestrator: collect plans → resolve → judge → retry → narrate → commit.
-Broadcasts progress via Supabase Realtime.
+Integration points already stubbed in `lib/game/game-loop.ts` (PR #49).
 
 Files:
-- Modify: `app/api/branches/[branchId]/advance/route.ts`
-- Create: `lib/game/game-loop.ts`
+- Modify: `lib/game/game-loop.ts` (implement full orchestration)
+- Modify: `app/api/scenarios/[id]/branches/[branchId]/advance/route.ts` (call game loop)
 - Create: `tests/game/game-loop.test.ts`
 
 Acceptance criteria:
-- [ ] POST /api/branches/[branchId]/advance runs full turn
-- [ ] Supabase Realtime broadcasts: turn_started, resolution_progress, turn_completed
-- [ ] New scenario_commit created with turn results
-- [ ] DispatchTerminal shows live progress from Realtime events
+- [ ] POST /api/scenarios/[id]/branches/[branchId]/advance runs full turn with AI
+- [ ] SSE streams real dispatch lines from resolution progress
+- [ ] New turn_commit created with narrative_entry from narrator
 - [ ] Turn number increments in Supabase
 
 ---
 
-### PHASE C: Player Interaction (depends on Phases A + B)
+### PHASE C: Player Interaction
 
-**Issue #62: Turn plan submission flow**
+**Issue #37 (scrum #62): Turn plan submission flow**
 Title: `feat: Player turn submission — TurnPlanBuilder → game loop trigger`
 Labels: `P0-critical`, `frontend`
-Depends on: #53, #61
+Depends on: #28 (bugs fixed), #36
 
-Wire TurnPlanBuilder's submit button to POST TurnPlan and trigger game loop.
+Status: advance route and useSubmitTurn hook exist (PR #50). Full AI game loop not yet wired.
 
 Files:
-- Modify: `components/panels/TurnPlanBuilder.tsx` (add onSubmit handler)
-- Modify: `components/game/GameView.tsx` (handle submit, show loading in DispatchTerminal)
-- Create: `hooks/useSubmitTurn.ts`
+- Modify: `components/panels/TurnPlanBuilder.tsx` (verify submit wiring)
+- Modify: `components/game/GameView.tsx` (handle AI response in DispatchTerminal)
+- Modify: `hooks/useSubmitTurn.ts` (already updated in PR #50)
 
 Acceptance criteria:
 - [ ] Player selects primary decision + optional concurrent actions
-- [ ] Submit POSTs to /api/branches/[branchId]/advance
-- [ ] DispatchTerminal shows "SUBMITTING TURN PLAN..." while waiting
-- [ ] ChronicleTimeline updates with new entry on completion
+- [ ] Submit POSTs to /api/scenarios/[id]/branches/[branchId]/advance
+- [ ] DispatchTerminal shows real SSE dispatch lines from resolution
+- [ ] ChronicleTimeline updates with AI-generated narrative on completion
 - [ ] TurnPlanBuilder resets after submission
 
 ---
 
-**Issue #63: Branching — create alternate branches**
+**Issue #38 (scrum #63): Branching — create alternate branches**
 Title: `feat: Branch creation — player diverges from trunk`
 Labels: `P1-important`, `backend`
-Depends on: #61
+Depends on: #36
 
 Files:
-- Modify: `app/api/branches/route.ts` (POST to create branch)
-- Create: `app/scenarios/[id]/branches/page.tsx` (branch list UI)
+- Modify or create: `app/api/scenarios/[id]/branches/route.ts` (POST to create branch)
+- Modify: `components/scenario/BranchTree.tsx` (enable branch creation from a node)
 
 Acceptance criteria:
-- [ ] POST /api/branches creates branch from given commit_id
-- [ ] Branch list page shows all branches for a scenario
+- [ ] POST /api/scenarios/[id]/branches creates branch from given turn_commit_id
+- [ ] New branch appears in BranchTree
 - [ ] New branch is playable at /scenarios/[id]/play/[newBranchId]
-
----
-
-**Issue #64: Mapbox Tier 1 — real map implementation**
-Title: `feat: Mapbox GL — country fills, chokepoint markers, actor positions`
-Labels: `P1-important`, `frontend`
-Depends on: #53
-
-Files:
-- Modify: `components/map/GameMap.tsx` (add Mapbox GL JS initialization)
-- Modify: `components/map/ActorLayer.tsx` (render actor positions)
-- Modify: `components/map/ChokepointMarker.tsx` (render Hormuz, Bab-el-Mandeb)
-
-Acceptance criteria:
-- [ ] Dark map renders in play view (no placeholder)
-- [ ] Iran, US (carrier), Israel, Gulf States positions shown
-- [ ] Strait of Hormuz marker visible with CLOSED status
-- [ ] FloatingMetricChip overlays positioned correctly
 
 ---
 
 ### PHASE D: Auth & Infrastructure
 
-**Issue #65: Real authentication flow**
+**Issue #40 (scrum #65): Real authentication flow**
 Title: `feat: Supabase Auth — replace dev bypass with real auth`
 Labels: `P1-important`, `infrastructure`
 
+Status: auth pages exist, dev bypass active. RLS enforced but bypass circumvents it.
+
 Files:
-- Create: `app/auth/login/page.tsx`
-- Create: `app/auth/callback/route.ts`
-- Modify: `middleware.ts` (real auth check)
+- Modify: `middleware.ts` (enforce real auth check in non-dev mode)
+- Verify: `app/auth/login/page.tsx`, `app/auth/callback/route.ts`
 
 Acceptance criteria:
 - [ ] Users can sign in via Supabase Auth
@@ -322,7 +262,7 @@ Acceptance criteria:
 
 ---
 
-**Issue #66: CI/CD pipeline**
+**Issue #41 (scrum #66): CI/CD pipeline**
 Title: `feat: GitHub Actions CI with Vitest, typecheck, lint`
 Labels: `P0-critical`, `infrastructure`
 
@@ -339,52 +279,48 @@ Acceptance criteria:
 ## Dependency Chain
 
 ```
-#52 (seed)
-  └── #53 (real data wiring)
-        └── #62 (turn submission)
-        └── #64 (Mapbox)
+Bug fixes (new)
+  └── Real data stable
+        └── #37 (turn submission — full AI)
 
-#52 (seed)
-  └── #56 (research pipeline)
-        └── #57 (actor agent)
-              └── #58 (resolution engine)
-                    └── #59 (judge)
-                          └── #60 (narrator)
-                                └── #61 (game loop)
-                                      └── #62 (turn submission)
-                                      └── #63 (branching)
+#31 (research pipeline)
+  └── #32 (actor agent — TurnPlan)
+        └── #33 (resolution engine)
+              └── #34 (judge)
+                    └── #35 (narrator)
+                          └── #36 (game loop controller)
+                                └── #37 (turn submission — full AI)
+                                └── #38 (branching)
 
 Independent (can start any time):
-  #54 (landing page)
-  #55 (animations)
-  #65 (auth)
-  #66 (CI/CD)
+  #40 (auth)
+  #41 (CI/CD)
 ```
 
-## Feature Alignment
+## GitHub Issue → Scrum Doc Map
 
-| Feature | Issue | Status |
-|---------|-------|--------|
-| Infrastructure + game logic | #1–#8 | Done |
-| Design tokens + UI primitives | Sprint 2 | Done |
-| Game components + panels | Sprint 2 | Done |
-| War Chronicle | Sprint 2 | Done |
-| Map shell | Sprint 2 | Done |
-| GameView layout | Sprint 2 | Done |
-| Scenario Hub + Browser | Sprint 2 | Done |
-| Realtime shell | Sprint 2 | Done |
-| Iran scenario seed | #52 | Pending |
-| Real data wiring | #53 | Pending |
-| Landing page | #54 | Pending |
-| Animations pass | #55 | Pending |
-| Research pipeline | #56 | Pending |
-| Actor agent | #57 | Pending |
-| Resolution engine | #58 | Pending |
-| Judge evaluator | #59 | Pending |
-| Narrator | #60 | Pending |
-| Game loop controller | #61 | Pending |
-| Turn submission | #62 | Pending |
-| Branching UI | #63 | Pending |
-| Mapbox Tier 1 | #64 | Pending |
-| Auth | #65 | Pending |
-| CI/CD | #66 | Pending |
+| GitHub # | Scrum # | Title | Status |
+|----------|---------|-------|--------|
+| #1–#9    | —       | Sprint 1 foundation | ✅ CLOSED |
+| #10      | —       | App layout + routing | ✅ DONE (close) |
+| #11      | —       | Shared UI components | ✅ DONE (close) |
+| #12      | —       | Mapbox GL shell | ✅ DONE (close) |
+| #18      | —       | Iran research incorporation | ✅ CLOSED |
+| #20–#25  | —       | Sprint 2 Stitch migration | ✅ CLOSED |
+| #27      | #52     | Iran seed | ✅ DONE → close, link PR #48 |
+| #28      | #53     | Wire real data | ✅ DONE → close, link PR #50 |
+| #29      | #54     | Landing page | ✅ CLOSED |
+| #30      | #55     | Animations | ✅ CLOSED |
+| #31      | #56     | Research pipeline | 🔲 OPEN |
+| #32      | #57     | Actor agent | 🔲 OPEN (partial) |
+| #33      | #58     | Resolution engine | 🔲 OPEN |
+| #34      | #59     | Judge agent | 🔲 OPEN |
+| #35      | #60     | Narrator | 🔲 OPEN |
+| #36      | #61     | Game loop controller | 🔲 OPEN |
+| #37      | #62     | Turn submission | 🔲 OPEN (partial) |
+| #38      | #63     | Branch creation | 🔲 OPEN |
+| #39      | #64     | Mapbox real impl | ✅ CLOSED |
+| #40      | #65     | Auth | 🔲 OPEN (partial) |
+| #41      | #66     | CI/CD | 🔲 OPEN |
+| new      | —       | Playable game bug fixes (11 bugs) | 🔲 CREATE |
+| new      | —       | Live State Engine | ✅ DONE — PR #49 (no GH issue existed) |

--- a/docs/superpowers/plans/2026-04-09-playable-game-bug-fixes.md
+++ b/docs/superpowers/plans/2026-04-09-playable-game-bug-fixes.md
@@ -1,0 +1,856 @@
+# Playable Game Bug Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 11 post-merge bugs blocking the playable game: broken API calls, wrong column names, hardcoded URLs, missing API fallbacks, exposed admin UI, and wrong CSS z-index.
+
+**Architecture:** Each task is a standalone fix with no dependencies between tasks (except Task 2 depends on Task 1 reshaping the route response). All changes are on branch `fix/playable-game-bugs`. No new files except a favicon asset.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, Supabase, Vitest, Tailwind CSS
+
+**Bug reference:** `docs/bugs/2026-04-09-playable-game-bugs.md` — read this file for full context on root causes.
+
+---
+
+## File Map
+
+| File | Bugs Fixed |
+|------|-----------|
+| `app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts` | Bug 3 |
+| `components/map/GameMap.tsx` | Bug 2, Bug 4 (response parsing) |
+| `app/scenarios/[id]/page.tsx` | Bug 1, Bug 11 |
+| `app/scenarios/[id]/play/[branchId]/page.tsx` | Bug 7, Bug 8 |
+| `components/game/GameView.tsx` | Bug 5, Bug 9 |
+| `components/ui/TopBar.tsx` | Bug 6 |
+| `public/favicon.svg` | Issue #57 |
+| `tests/api/map-assets.test.ts` | Bug 3 test |
+
+---
+
+### Task 1: Fix map-assets route — make `turnCommitId` optional (Bug 3)
+
+**Files:**
+- Modify: `app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts:48-50`
+- Modify: `tests/api/map-assets.test.ts` (add new test case)
+
+**Context:** The route currently returns 400 if `turnCommitId` query param is missing. On first page load `GameMap` may not have the commit ID yet, so the map is blank. Fix: when `turnCommitId` is absent, skip `getStateAtTurn` and go straight to the `actor_capabilities` fallback (which always has lat/lng). The route's `params.id` is the scenario ID — use it directly for the fallback query.
+
+- [ ] **Step 1: Add a failing test for the optional-turnCommitId case**
+
+Open `tests/api/map-assets.test.ts`. Add this test at the end of the describe block:
+
+```typescript
+it('returns 200 with actor_capabilities assets when turnCommitId is missing', async () => {
+  // The route should not 400 when turnCommitId is absent
+  const req = new Request(
+    'http://localhost:3000/api/scenarios/test-scenario/branches/test-branch/map-assets',
+    { method: 'GET' }
+  )
+  const params = { id: 'test-scenario', branchId: 'test-branch' }
+
+  // Mock supabase to return one capability row
+  vi.mocked(createServerClient).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        not: vi.fn().mockReturnValue({
+          not: vi.fn().mockResolvedValue({
+            data: [{
+              id: 'cap-1',
+              actor_id: 'iran',
+              name: 'Fordow Nuclear Facility',
+              asset_type: 'nuclear_facility',
+              category: null,
+              lat: 34.88,
+              lng: 49.93,
+              status: 'operational',
+              description: 'Underground enrichment site',
+            }],
+            error: null,
+          }),
+        }),
+      }),
+      eq: vi.fn().mockReturnThis(),
+    }),
+  } as ReturnType<typeof createServerClient>)
+
+  const { GET } = await import('@/app/api/scenarios/[id]/branches/[branchId]/map-assets/route')
+  const response = await GET(req, { params })
+
+  expect(response.status).toBe(200)
+  const body = await response.json()
+  expect(body.data.assets.length).toBeGreaterThan(0)
+  expect(body.data.assets[0].actor_id).toBe('iran')
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bun run test -- --run tests/api/map-assets.test.ts --reporter=verbose
+```
+
+Expected: FAIL — the route returns 400 when `turnCommitId` is missing.
+
+- [ ] **Step 3: Rewrite the route GET handler**
+
+Replace lines 37–140 of `app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts` with:
+
+```typescript
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string; branchId: string } }
+) {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 503 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const turnCommitId = searchParams.get('turnCommitId')
+
+  try {
+    const supabase = await createClient()
+    const assets: MapAsset[] = []
+
+    if (turnCommitId) {
+      // Prefer state-engine data when we have a commit reference
+      const state = await getStateAtTurn(params.branchId, turnCommitId)
+
+      const stateAssets: MapAsset[] = state.facility_statuses
+        .filter(f => f.lat !== undefined && f.lng !== undefined)
+        .map(f => ({
+          id:                      `${f.actor_id}-${f.name.toLowerCase().replace(/\s+/g, '-')}`,
+          actor_id:                f.actor_id,
+          asset_type:              facilityTypeToMapAssetType(f.type),
+          label:                   f.name,
+          lat:                     f.lat!,
+          lng:                     f.lng!,
+          status:                  f.status,
+          capacity_pct:            f.capacity_pct,
+          actor_color:             ACTOR_COLORS[f.actor_id] ?? '#888888',
+          tooltip:                 `${f.name} — ${f.status} (${f.capacity_pct}% capacity). ${f.location_label}`,
+          is_approximate_location: f.type === 'carrier_group' || f.type === 'troop_deployment',
+        }))
+
+      assets.push(...stateAssets)
+
+      // Fallback within the turnCommitId path: if facility_statuses had no coordinates
+      if (assets.length === 0) {
+        await fillFromCapabilities(supabase, params.id, assets)
+      }
+
+      const shipping_lanes: ShippingLane[] = [
+        {
+          id:             'strait_of_hormuz',
+          label:          'Strait of Hormuz',
+          throughput_pct: state.global_state.hormuz_throughput_pct,
+          coordinates:    HORMUZ_COORDINATES,
+        },
+      ]
+
+      const response: MapAssetsResponse = {
+        turn_commit_id: turnCommitId,
+        as_of_date:     state.as_of_date,
+        assets,
+        shipping_lanes,
+      }
+      return NextResponse.json({ data: response })
+    }
+
+    // No turnCommitId — return static capability snapshot
+    await fillFromCapabilities(supabase, params.id, assets)
+
+    const shipping_lanes: ShippingLane[] = [
+      {
+        id:             'strait_of_hormuz',
+        label:          'Strait of Hormuz',
+        throughput_pct: 100,
+        coordinates:    HORMUZ_COORDINATES,
+      },
+    ]
+
+    const response: MapAssetsResponse = {
+      turn_commit_id: '',
+      as_of_date:     new Date().toISOString().split('T')[0],
+      assets,
+      shipping_lanes,
+    }
+    return NextResponse.json({ data: response })
+
+  } catch (err) {
+    console.error('[map-assets] Error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+```
+
+Also extract the actor_capabilities fetch into a helper function, inserted after the `ACTOR_COLORS` block and before the `facilityTypeToMapAssetType` function:
+
+```typescript
+async function fillFromCapabilities(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  scenarioId: string,
+  assets: MapAsset[]
+): Promise<void> {
+  const { data: caps } = await supabase
+    .from('actor_capabilities')
+    .select('id, actor_id, name, asset_type, category, lat, lng, status, description')
+    .eq('scenario_id', scenarioId)
+    .not('lat', 'is', null)
+    .not('lng', 'is', null)
+
+  if (!caps) return
+
+  const typeMap: Record<string, string> = {
+    nuclear_facility: 'nuclear_facility', oil_gas_facility: 'oil_gas_facility',
+    military_base: 'military_base', carrier: 'carrier_group',
+    carrier_group: 'carrier_group', naval_base: 'naval_asset',
+    airbase: 'military_base', headquarters: 'military_base',
+    missile_battery: 'missile_battery',
+  }
+
+  for (const cap of caps as Array<{
+    id: string; actor_id: string; name: string; asset_type: string | null
+    category: string | null; lat: number; lng: number; status: string | null
+    description: string | null
+  }>) {
+    const rawType = cap.asset_type ?? cap.category ?? 'military_base'
+    assets.push({
+      id:                      cap.id,
+      actor_id:                cap.actor_id,
+      asset_type:              (typeMap[rawType] ?? 'military_base') as MapAssetType,
+      label:                   cap.name,
+      lat:                     cap.lat,
+      lng:                     cap.lng,
+      status:                  cap.status === 'destroyed' ? 'destroyed' : cap.status === 'degraded' ? 'degraded' : 'operational',
+      capacity_pct:            100,
+      actor_color:             ACTOR_COLORS[cap.actor_id] ?? '#888888',
+      tooltip:                 cap.description ?? cap.name,
+      is_approximate_location: rawType === 'carrier' || rawType === 'carrier_group',
+    })
+  }
+}
+```
+
+Also remove the old inline fallback block (lines ~71-110 in the original — the `if (assets.length === 0)` block inside the try) since it is now handled by `fillFromCapabilities`.
+
+- [ ] **Step 4: Run tests to verify passing**
+
+```bash
+bun run test -- --run tests/api/map-assets.test.ts --reporter=verbose
+```
+
+Expected: all tests pass including the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts tests/api/map-assets.test.ts
+git commit -m "fix: make turnCommitId optional in map-assets route, fallback to actor_capabilities"
+```
+
+---
+
+### Task 2: Fix GameMap response parsing and remove hardcoded cities fetch (Bugs 2 & 4)
+
+**Files:**
+- Modify: `components/map/GameMap.tsx:69-83`
+
+**Context:**
+- Bug 2: `useEffect` at line ~79 fetches `/api/scenarios/iran-2026/cities` (hardcoded). Cities are already static GeoJSON in `MapboxMap.tsx`. Delete this useEffect entirely.
+- Bug 4: The map-assets fetch (line 73-75) destructures `{ assets: data }` but the route returns `{ data: { assets } }`. Change the destructuring to match the `{ data, error }` API convention.
+
+- [ ] **Step 1: Run existing tests to establish baseline**
+
+```bash
+bun run test -- --run --reporter=verbose 2>&1 | tail -10
+```
+
+Expected: all existing tests pass (note the count for comparison after fix).
+
+- [ ] **Step 2: Fix the map-assets fetch response parsing**
+
+In `components/map/GameMap.tsx`, find the first `useEffect` (around line 69-76):
+
+```typescript
+useEffect(() => {
+  if (!branchId) return
+  const url = `/api/scenarios/${scenarioId}/branches/${branchId}/map-assets${turnCommitId ? `?turnCommitId=${turnCommitId}` : ''}`
+  fetch(url)
+    .then(r => r.json())
+    .then(({ assets: data }: { assets: MapAsset[] | null }) => { if (data) setMapAssets(data) })
+    .catch(() => {})
+}, [scenarioId, branchId, turnCommitId])
+```
+
+Replace with:
+
+```typescript
+useEffect(() => {
+  if (!branchId) return
+  const url = `/api/scenarios/${scenarioId}/branches/${branchId}/map-assets${turnCommitId ? `?turnCommitId=${turnCommitId}` : ''}`
+  fetch(url)
+    .then(r => r.json())
+    .then(({ data }: { data: { assets: MapAsset[] } | null }) => {
+      if (data?.assets) setMapAssets(data.assets)
+    })
+    .catch(() => {})
+}, [scenarioId, branchId, turnCommitId])
+```
+
+- [ ] **Step 3: Delete the hardcoded cities fetch**
+
+In `components/map/GameMap.tsx`, find and delete this entire `useEffect` block (around lines 78-83):
+
+```typescript
+useEffect(() => {
+  fetch('/api/scenarios/iran-2026/cities')
+    .then(r => r.json())
+    .then(({ data }: { data: City[] | null }) => { if (data) setCities(data) })
+    .catch(() => {})
+}, [])
+```
+
+Delete the block. Cities are already hardcoded as static GeoJSON in `MapboxMap.tsx`.
+
+- [ ] **Step 4: Check if `City` type and `cities` state are now unused**
+
+After deleting the fetch, check if any other code in the file uses `cities` state or the `City` import. If `cities` state is only set in that deleted useEffect and only used by `MapboxMap`, check if `MapboxMap` receives `cities` as a prop.
+
+Run:
+```bash
+bun run typecheck 2>&1 | grep -E "GameMap|cities|City" | head -20
+```
+
+If there are unused variable errors, remove the `useState` for `cities` and the `City` import from `GameMap.tsx`. If `cities` is passed as a prop to `MapboxMap`, keep the state but initialize it as `[]` — the static GeoJSON in MapboxMap already handles cities.
+
+- [ ] **Step 5: Run tests to confirm no regressions**
+
+```bash
+bun run test -- --run --reporter=verbose 2>&1 | tail -10
+```
+
+Expected: same test count as baseline, all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/map/GameMap.tsx
+git commit -m "fix: correct map-assets response parsing and remove hardcoded cities fetch"
+```
+
+---
+
+### Task 3: Fix actors query column names in Scenario Hub (Bug 1)
+
+**Files:**
+- Modify: `app/scenarios/[id]/page.tsx:331-346`
+
+**Context:** The Supabase query selects `id, name, country_code` from `actors`. The actors table has no `id` column (PK is `actor_id`) and no `country_code` column. Supabase returns 400, leaving `actorOptions` empty and the actor perspective selector blank.
+
+- [ ] **Step 1: Fix the actors query**
+
+In `app/scenarios/[id]/page.tsx`, find the actors fetch inside the `useEffect` (around line 329-332):
+
+```typescript
+supabase
+  .from('actors')
+  .select('id, name, country_code')
+  .eq('scenario_id', params.id),
+```
+
+Replace with:
+
+```typescript
+supabase
+  .from('actors')
+  .select('actor_id, name')
+  .eq('scenario_id', params.id),
+```
+
+- [ ] **Step 2: Fix the actorOptions mapping**
+
+Find the actorOptions mapping (around lines 339-347):
+
+```typescript
+if (actorRes.data) {
+  setActorOptions(
+    actorRes.data.map((a: Record<string, unknown>) => ({
+      id: a.id as string,
+      name: a.name as string,
+      flag: ((a.country_code as string | null) ?? (a.name as string).slice(0, 3)).toUpperCase(),
+    }))
+  )
+}
+```
+
+Replace with:
+
+```typescript
+if (actorRes.data) {
+  setActorOptions(
+    actorRes.data.map((a: Record<string, unknown>) => ({
+      id: a.actor_id as string,
+      name: a.name as string,
+      flag: (a.name as string).slice(0, 3).toUpperCase(),
+    }))
+  )
+}
+```
+
+- [ ] **Step 3: Run typecheck to confirm no type errors**
+
+```bash
+bun run typecheck 2>&1 | grep -E "page.tsx" | head -20
+```
+
+Expected: no errors from this file.
+
+- [ ] **Step 4: Run all tests to confirm no regressions**
+
+```bash
+bun run test -- --run 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/scenarios/[id]/page.tsx"
+git commit -m "fix: correct actors query columns — actor_id not id, remove country_code"
+```
+
+---
+
+### Task 4: Fix play page actors and chronicle queries (Bugs 7 & 8)
+
+**Files:**
+- Modify: `app/scenarios/[id]/play/[branchId]/page.tsx:44-65`
+
+**Context:** Both bugs share the same root cause — if `params.id` is a URL slug (e.g., `iran-2026`) but the scenario row's PK is a UUID, then actors queried by `.eq('scenario_id', params.id)` return empty. Fix: use `scenario?.id` (the actual DB row ID returned from the first fetch) for all subsequent queries. Similarly, the chronicle query uses `params.branchId` — verify the branch record exists first and use `branch?.id`.
+
+- [ ] **Step 1: Fix actors query to use fetched scenario ID**
+
+In `app/scenarios/[id]/play/[branchId]/page.tsx`, find the actors fetch (around line 44-48):
+
+```typescript
+const { data: actorRows } = await supabase
+  .from('actors')
+  .select('actor_id, name, win_condition, lose_condition, strategic_posture, escalation_ladder')
+  .eq('scenario_id', params.id)
+```
+
+Replace with:
+
+```typescript
+const { data: actorRows } = await supabase
+  .from('actors')
+  .select('actor_id, name, win_condition, lose_condition, strategic_posture, escalation_ladder')
+  .eq('scenario_id', scenario?.id ?? params.id)
+```
+
+- [ ] **Step 2: Fix chronicle query to use fetched branch ID**
+
+Find the turn_commits query (around line 61-65):
+
+```typescript
+const { data: commits } = await supabase
+  .from('turn_commits')
+  .select('turn_number, simulated_date, narrative_entry')
+  .eq('branch_id', params.branchId)
+  .order('turn_number', { ascending: true })
+```
+
+Replace with:
+
+```typescript
+const { data: commits } = await supabase
+  .from('turn_commits')
+  .select('turn_number, simulated_date, narrative_entry')
+  .eq('branch_id', branch?.id ?? params.branchId)
+  .order('turn_number', { ascending: true })
+```
+
+- [ ] **Step 3: Add dev-mode diagnostic logging**
+
+After the `groundTruthCommits` fetch (around line 80), add:
+
+```typescript
+if (process.env.NODE_ENV === 'development') {
+  console.log('[play page] params:', { id: params.id, branchId: params.branchId })
+  console.log('[play page] scenario?.id:', scenario?.id)
+  console.log('[play page] branch?.id:', branch?.id)
+  console.log('[play page] actorRows?.length:', actorRows?.length ?? 0)
+  console.log('[play page] commits?.length:', commits?.length ?? 0)
+}
+```
+
+- [ ] **Step 4: Run typecheck**
+
+```bash
+bun run typecheck 2>&1 | grep "play" | head -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+bun run test -- --run 2>&1 | tail -5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/scenarios/[id]/play/[branchId]/page.tsx"
+git commit -m "fix: use fetched scenario.id and branch.id for actors and chronicle queries"
+```
+
+---
+
+### Task 5: Remove ResearchUpdatePanel from GameView (Bug 5)
+
+**Files:**
+- Modify: `components/game/GameView.tsx`
+
+**Context:** `<ResearchUpdatePanel>` is an admin/dev tool (triggers 7-stage AI pipeline). It's imported and rendered unconditionally in the observer mode section. Remove it from the game UI entirely — research updates are a backend admin operation.
+
+- [ ] **Step 1: Remove the import**
+
+In `components/game/GameView.tsx`, find and delete line 18:
+
+```typescript
+import { ResearchUpdatePanel } from '@/components/game/ResearchUpdatePanel'
+```
+
+- [ ] **Step 2: Remove the JSX block**
+
+Find and delete this block (around lines 432-436):
+
+```typescript
+          {/* Ground truth research panel */}
+          <div className="shrink-0 p-3 border-t border-border-subtle">
+            <ResearchUpdatePanel scenarioId={scenarioId} />
+          </div>
+```
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+bun run typecheck 2>&1 | grep "GameView" | head -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+bun run test -- --run 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/game/GameView.tsx
+git commit -m "fix: remove ResearchUpdatePanel from game UI — admin-only tool"
+```
+
+---
+
+### Task 6: Hide decisions panel in observer mode (Bug 9)
+
+**Files:**
+- Modify: `components/game/GameView.tsx`
+
+**Context:** In observer (ground truth) mode, `isGtMode = true`. The decisions tab and content are still shown with only US decisions. In observer mode, the player has no actor — decisions are irrelevant. Fix: filter the PANEL_TABS list to exclude 'decisions' when `isGtMode` is true.
+
+- [ ] **Step 1: Filter tabs based on mode**
+
+In `components/game/GameView.tsx`, find the `PANEL_TABS` constant (around line 36-41):
+
+```typescript
+const PANEL_TABS: { id: PanelTab; label: string }[] = [
+  { id: 'actors',    label: 'ACTORS'    },
+  { id: 'decisions', label: 'DECISIONS' },
+  { id: 'events',    label: 'EVENTS'    },
+  { id: 'chronicle', label: 'CHRONICLE' },
+]
+```
+
+This is a module-level constant — it can't reference `isGtMode`. Instead, find where tabs are rendered (around line 360):
+
+```typescript
+{PANEL_TABS.map(({ id, label }) => (
+```
+
+Replace with:
+
+```typescript
+{PANEL_TABS.filter(t => !isGtMode || t.id !== 'decisions').map(({ id, label }) => (
+```
+
+- [ ] **Step 2: Also guard the decisions tab content**
+
+Find the decisions tab content (around line 385-392):
+
+```typescript
+{activeTab === 'decisions' && (
+  <DecisionCatalog
+    decisions={initialData.decisions}
+    onSelect={handleDecisionSelect}
+    selectedPrimaryId={primaryAction?.id ?? null}
+    selectedConcurrentIds={concurrentActions.map(a => a.id)}
+  />
+)}
+```
+
+Replace with:
+
+```typescript
+{activeTab === 'decisions' && !isGtMode && (
+  <DecisionCatalog
+    decisions={initialData.decisions}
+    onSelect={handleDecisionSelect}
+    selectedPrimaryId={primaryAction?.id ?? null}
+    selectedConcurrentIds={concurrentActions.map(a => a.id)}
+  />
+)}
+```
+
+- [ ] **Step 3: Run typecheck and tests**
+
+```bash
+bun run typecheck 2>&1 | grep "GameView" | head -10
+bun run test -- --run 2>&1 | tail -5
+```
+
+Expected: no errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/game/GameView.tsx
+git commit -m "fix: hide decisions tab in observer (ground truth) mode"
+```
+
+---
+
+### Task 7: Fix TopBar hardcoded defaults (Bug 6)
+
+**Files:**
+- Modify: `components/ui/TopBar.tsx:21-28`
+
+**Context:** TopBar defaults `turnNumber = 4` and `totalTurns = 12`. When the game loads with real data but `turnNumber = 0` (empty branch), the defaults show "04/12" instead of real values. Change defaults to `0`.
+
+- [ ] **Step 1: Update defaults**
+
+In `components/ui/TopBar.tsx`, find:
+
+```typescript
+export function TopBar({
+  scenarioName = "Iran Conflict Scenario",
+  scenarioHref,
+  turnNumber = 4,
+  totalTurns = 12,
+  phase = "Planning",
+  gameMode = "Simulation",
+}: TopBarProps) {
+```
+
+Replace with:
+
+```typescript
+export function TopBar({
+  scenarioName = "Iran Conflict Scenario",
+  scenarioHref,
+  turnNumber = 0,
+  totalTurns = 0,
+  phase = "Planning",
+  gameMode = "Simulation",
+}: TopBarProps) {
+```
+
+- [ ] **Step 2: Handle zero display**
+
+In the same file, find the turn counter span (around line 65-68):
+
+```typescript
+<span className="font-mono text-xs text-text-tertiary">
+  TURN {String(turnNumber).padStart(2, "0")} /{" "}
+  {String(totalTurns).padStart(2, "0")}
+</span>
+```
+
+Replace with:
+
+```typescript
+<span className="font-mono text-xs text-text-tertiary">
+  {turnNumber > 0 || totalTurns > 0
+    ? `TURN ${String(turnNumber).padStart(2, '0')} / ${String(totalTurns).padStart(2, '0')}`
+    : 'TURN — / —'}
+</span>
+```
+
+- [ ] **Step 3: Run typecheck and tests**
+
+```bash
+bun run typecheck 2>&1 | grep "TopBar" | head -5
+bun run test -- --run 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ui/TopBar.tsx
+git commit -m "fix: remove hardcoded turn 4/12 defaults from TopBar"
+```
+
+---
+
+### Task 8: Fix branch creation placeholder message (Bug 11)
+
+**Files:**
+- Modify: `app/scenarios/[id]/page.tsx:379`
+
+**Context:** When a user clicks "Start New Branch," the handler immediately throws `'Branch creation is not available yet.'` This message is jarring — it implies a broken feature. Change it to explain it's available in player mode.
+
+- [ ] **Step 1: Update the error message**
+
+In `app/scenarios/[id]/page.tsx`, find (around line 379):
+
+```typescript
+      setBranchError('Branch creation is not available yet.')
+```
+
+Replace with:
+
+```typescript
+      setBranchError('Branching is available from the Play page after selecting a turn.')
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+bun run typecheck 2>&1 | grep "page.tsx" | head -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "app/scenarios/[id]/page.tsx"
+git commit -m "fix: improve branch creation placeholder message"
+```
+
+---
+
+### Task 9: Add favicon (Issue #57)
+
+**Files:**
+- Create: `public/favicon.svg`
+
+**Context:** The browser console shows a 404 for `/favicon.ico`. Next.js supports SVG favicons placed in `public/` or in `app/favicon.ico`. The simplest fix is a minimal SVG favicon in `public/`.
+
+- [ ] **Step 1: Create the favicon**
+
+Create `public/favicon.svg` with:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#050A12"/>
+  <text x="4" y="24" font-family="monospace" font-size="20" font-weight="bold" fill="#ffba20">G</text>
+</svg>
+```
+
+- [ ] **Step 2: Add favicon link to root layout**
+
+Open `app/layout.tsx`. Check if there is already a `<link rel="icon">` tag or a `metadata.icons` export. If not, add:
+
+In the `metadata` export (or create one if absent):
+
+```typescript
+export const metadata = {
+  // ... existing fields ...
+  icons: {
+    icon: '/favicon.svg',
+  },
+}
+```
+
+If `app/layout.tsx` uses a `<head>` block with JSX, add:
+```html
+<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+```
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+bun run typecheck 2>&1 | grep "layout" | head -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/favicon.svg app/layout.tsx
+git commit -m "fix: add SVG favicon to resolve 404"
+```
+
+---
+
+### Task 10: Final check — typecheck, lint, full test run
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run full typecheck**
+
+```bash
+bun run typecheck 2>&1 | tail -10
+```
+
+Expected: `Found 0 errors.`
+
+- [ ] **Step 2: Run lint**
+
+```bash
+bun run lint 2>&1 | tail -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+bun run test -- --run --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit any cleanup**
+
+If typecheck or lint surfaced minor issues (unused imports after deletions), fix them, then:
+
+```bash
+git add -u
+git commit -m "fix: cleanup after bug fixes — unused imports and lint warnings"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Bug 1 (actors columns) → Task 3 ✅
+- Bug 2 (hardcoded cities) → Task 2 ✅
+- Bug 3 (map-assets 400) → Task 1 ✅
+- Bug 4 (map empty) → Task 1 + Task 2 (response parsing) ✅
+- Bug 5 (ResearchUpdatePanel) → Task 5 ✅
+- Bug 6 (TopBar defaults) → Task 7 ✅
+- Bug 7 (actors blank) → Task 4 ✅
+- Bug 8 (chronicle empty) → Task 4 ✅
+- Bug 9 (decisions in observer) → Task 6 ✅
+- Bug 10 (panel z-index) → Not planned — z-index conflict requires visual inspection in browser; deferred to playwright validation after this plan executes.
+- Bug 11 (branch creation text) → Task 8 ✅
+- Issue #57 (favicon) → Task 9 ✅
+
+**Deferred:** Bug 10 (z-index) requires browser-based visual debugging. After this plan is merged, run `geosim-playwright` to identify exact element overlap and fix in a follow-up commit.
+
+**Placeholder scan:** None found.
+
+**Type consistency:** `MapAssetsResponse` used consistently across Task 1 and Task 2. `ActorSummary.id` sourced from `actor_id` in both Task 3 and existing play page code.

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#050A12"/>
+  <text x="4" y="24" font-family="monospace" font-size="20" font-weight="bold" fill="#ffba20">G</text>
+</svg>

--- a/tests/api/map-assets.test.ts
+++ b/tests/api/map-assets.test.ts
@@ -3,10 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('@/lib/game/state-engine', () => ({
   getStateAtTurn: vi.fn(),
 }))
-vi.mock('@/lib/supabase/server')
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
 
 import { GET } from '@/app/api/scenarios/[id]/branches/[branchId]/map-assets/route'
 import { getStateAtTurn } from '@/lib/game/state-engine'
+import { createClient } from '@/lib/supabase/server'
 import type { BranchStateAtTurn } from '@/lib/types/simulation'
 
 function makeState(): BranchStateAtTurn {
@@ -119,10 +122,43 @@ describe('GET /api/scenarios/[id]/branches/[branchId]/map-assets', () => {
     expect(body.data.assets).toHaveLength(2) // only the 2 with coordinates
   })
 
-  it('returns 400 when turnCommitId is missing', async () => {
-    const req = makeRequest('br-1') // no query params
+  it('returns 200 with assets from actor_capabilities when turnCommitId is missing', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              not: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: 'cap-1',
+                    actor_id: 'iran',
+                    name: 'Fordow Nuclear Site',
+                    asset_type: 'nuclear_facility',
+                    category: null,
+                    lat: 34.89,
+                    lng: 49.93,
+                    status: 'operational',
+                    description: 'Uranium enrichment facility',
+                  },
+                ],
+              }),
+            }),
+          }),
+        }),
+      }),
+    }
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never)
+
+    const req = makeRequest('br-1') // no turnCommitId
     const res = await GET(req, { params: { id: 'sc-1', branchId: 'br-1' } })
-    expect(res.status).toBe(400)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.data.assets).toHaveLength(1)
+    expect(body.data.assets[0].actor_id).toBe('iran')
+    expect(body.data.assets[0].lat).toBe(34.89)
+    expect(body.data.turn_commit_id).toBe('')
   })
 
   it('returns 500 when getStateAtTurn throws', async () => {
@@ -132,6 +168,6 @@ describe('GET /api/scenarios/[id]/branches/[branchId]/map-assets', () => {
     const res = await GET(req, { params: { id: 'sc-1', branchId: 'br-1' } })
     expect(res.status).toBe(500)
     const body = await res.json()
-    expect(body.error).toContain('DB error')
+    expect(body.error).toBe('Internal server error')
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
-    exclude: ['node_modules', '.worktrees/**'],
+    exclude: ['node_modules', '.worktrees/**', 'tests/e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Fixes 10 of 11 post-merge bugs catalogued in `docs/bugs/2026-04-09-playable-game-bugs.md` that were blocking the game from being playable after PR #50 merged. One P2 bug (panel z-index overlap) deferred for browser-based debugging.

Closes #51
Closes #57

## Bugs Fixed

### P0 — Core data pipeline broken

**Bug 1 — Actors query used wrong column names (400 error)**
- `app/scenarios/[id]/page.tsx` was selecting `id, name, country_code` from `actors`
- Actors table PK is `actor_id`, no `country_code` column → Supabase returned 400
- Fixed: query now selects `actor_id, name`; flag derived from `name.slice(0, 3)`

**Bug 2 — Hardcoded `/api/scenarios/iran-2026/cities` fetch (500 error)**
- `GameMap.tsx` had a hardcoded city fetch that pointed to a non-existent route
- Cities are already static GeoJSON in `MapboxMap.tsx` — fetch was entirely redundant
- Fixed: deleted the `useEffect` entirely

**Bug 3 — map-assets route returned 400 when `turnCommitId` missing**
- Route required `?turnCommitId=` param and returned 400 without it
- On first page load, `GameMap` fetches before commit ID is available
- Fixed: `turnCommitId` is now optional; when absent, route falls back directly to `actor_capabilities` table (which always has coordinates). Extracted `fillFromCapabilities` helper to avoid duplication.

**Bug 4 — Map assets not rendering (response parsing mismatch)**
- `GameMap.tsx` destructured `{ assets: data }` from the fetch response
- Route returns `{ data: { assets: [...] } }` — `assets` was never at the top level
- Fixed: destructuring now reads `{ data }` and accesses `data.assets`

**Bug 7 — Actors tab blank in play page**
- `actors` query used `params.id` (URL slug) but actors table `scenario_id` stores the DB UUID
- Fixed: query now uses `scenario?.id ?? params.id` (fetched scenario row ID)

**Bug 8 — Chronicle/events tab empty**
- Same root cause as Bug 7 — `turn_commits` queried with raw `params.branchId`
- Fixed: query now uses `branch?.id ?? params.branchId`
- Added dev-mode diagnostic logging to surface future slug/UUID mismatches

### P1 — Wrong UI shown

**Bug 5 — "Run Research Update" admin button visible to all users**
- `<ResearchUpdatePanel>` triggers the 7-stage AI pipeline — admin-only tool
- Rendered unconditionally in game layout with no permission check
- Fixed: removed import and JSX from `GameView.tsx`

**Bug 9 — Decisions panel shown in observer (ground truth) mode**
- In observer mode (`isTrunk = true`), the DECISIONS tab still appeared with US-only options
- Fixed: tab strip filters out `'decisions'` when `isGtMode`; `DecisionCatalog` also guarded

### P2 — Visual / UX

**Bug 6 — TopBar showed "TURN 04 / 12" hardcoded defaults**
- Default props `turnNumber = 4` and `totalTurns = 12` showed on initial load
- Fixed: defaults changed to `0`; display shows `TURN — / —` when both are zero

**Bug 11 — "Branch creation is not available yet" jarring placeholder**
- Fixed: message changed to `"Branching is available from the Play page after selecting a turn."`

### Infrastructure

**Issue #57 — Favicon 404**
- Added `public/favicon.svg` (gold G mark on dark background)
- Added `icons` metadata to `app/layout.tsx`

**Vitest config — E2E tests excluded**
- `tests/e2e/**` excluded from Vitest runner to prevent Playwright type conflicts

## Files Changed

| File | Change |
|------|--------|
| `app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts` | Optional `turnCommitId`, extracted `fillFromCapabilities` helper |
| `components/map/GameMap.tsx` | Fixed response parsing, removed hardcoded cities fetch |
| `app/scenarios/[id]/page.tsx` | Fixed actors query columns, improved branch message |
| `app/scenarios/[id]/play/[branchId]/page.tsx` | Use fetched IDs for actors/chronicle queries |
| `components/game/GameView.tsx` | Removed ResearchUpdatePanel, hid decisions in observer mode |
| `components/ui/TopBar.tsx` | Removed hardcoded turn 4/12 defaults |
| `public/favicon.svg` | New — SVG favicon |
| `app/layout.tsx` | Added favicon metadata |
| `vitest.config.ts` | Excluded e2e tests from Vitest |
| `tests/api/map-assets.test.ts` | Added test for optional-turnCommitId path |

## Test Plan

- [x] 502/502 Vitest tests pass
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (1 pre-existing exhaustive-deps warning in MapboxMap)
- [ ] Manual: navigate to `/scenarios/iran-2026` — branch tree loads, actors listed
- [ ] Manual: navigate to play page — actors tab populated, chronicle visible
- [ ] Manual: map shows military assets on load (no 400/500 errors in devtools)
- [ ] Manual: observer mode has no DECISIONS tab
- [ ] Manual: TopBar shows real turn number (not 4/12)
- [ ] Manual: no "Run Research Update" button visible

## Deferred

- **Bug 10** (actor status panel overlaps map layer toggles) — P2, requires browser-based z-index debugging. Will fix in follow-up commit after visual inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)