### PR TITLE
feat: add GitHub Actions CI with typecheck, lint, vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  ci:
+    name: Typecheck, Lint, Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --run --reporter=verbose


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs on every `push` and `pull_request` to any branch
- Pipeline: `npm ci` → `npm run typecheck` → `npm run lint` → `npm test -- --run --reporter=verbose`
- Uses `actions/checkout@v4` + `actions/setup-node@v4` (Node 20, npm cache)
- `fail-fast: false` set for future matrix expansion

Closes #41

## Pre-existing test failures on `main`

The first CI run on this branch (and any PR targeting `main`) will likely report **4 pre-existing test failures** that already exist on `main`. These are **unrelated to this PR** and should be fixed (or `.skip`-ed) before enabling branch protection rules.

| File | Failing tests |
|------|---------------|
| `tests/middleware.test.ts` | All tests in this file |
| `tests/api/research-pipeline.test.ts` | All tests in this file |
| `tests/scripts/seed-iran.test.ts` | 3 tests |
| `tests/components/panels/TurnPlanBuilder.test.tsx` | 1 test |

**Recommended next step:** Fix or skip those 4 test files in a separate PR, then enable "Require status checks to pass" branch protection on `main`.

## Test plan

- [ ] Open a PR against `main` → observe CI job triggered
- [ ] Typecheck step passes (clean on this branch)
- [ ] Lint step passes (no new lint errors in this PR)
- [ ] Test step shows the 4 pre-existing failures listed above — no new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)