### PR TITLE
feat(ux): error boundaries and empty-state handling

### DIFF
--- a/components/chronicle/ChronicleTimeline.tsx
+++ b/components/chronicle/ChronicleTimeline.tsx
@@ -1,4 +1,5 @@
 import { TurnEntry } from './TurnEntry'
+import { EmptyState } from '@/components/game/EmptyState'
 
 type Severity = 'critical' | 'major' | 'moderate' | 'minor'
 
@@ -16,18 +17,30 @@ const severityLabel: Record<Severity, string> = {
   minor:    'Minor development',
 }
 
-export function ChronicleTimeline({ entries }: { entries: React.ComponentProps<typeof TurnEntry>['entry'][] }) {
+interface ChronicleTimelineProps {
+  entries: React.ComponentProps<typeof TurnEntry>['entry'][]
+  /** Pass true when the chronicle fetch errored out. */
+  fetchError?: boolean
+}
+
+export function ChronicleTimeline({ entries, fetchError = false }: ChronicleTimelineProps) {
+  if (fetchError) {
+    return (
+      <EmptyState
+        variant="error"
+        title="Chronicle Unavailable"
+        body="Unable to load chronicle data. Check your connection or refresh the page."
+      />
+    )
+  }
+
   if (entries.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center p-8 text-center gap-3" style={{ minHeight: 200 }}>
-        <div className="w-8 h-px" style={{ background: 'var(--border-subtle)' }} />
-        <div className="font-mono text-2xs uppercase tracking-[0.12em] text-text-tertiary">
-          No Chronicle Entries
-        </div>
-        <p className="font-serif italic text-sm text-text-tertiary leading-relaxed max-w-[240px]">
-          Chronicle entries appear here after each resolved turn. Step through Ground Truth or submit a turn plan to begin.
-        </p>
-      </div>
+      <EmptyState
+        variant="empty"
+        title="No Chronicle Entries"
+        body="Chronicle entries appear here after each resolved turn. Step through Ground Truth or submit a turn plan to begin."
+      />
     )
   }
 

--- a/components/game/EmptyState.tsx
+++ b/components/game/EmptyState.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+interface Props {
+  variant: 'empty' | 'error'
+  title: string
+  body?: string
+  action?: ReactNode
+}
+
+/**
+ * Consistent empty / error state block used across game panels.
+ *
+ * - `empty`  — neutral tone; valid/expected state (no data yet).
+ * - `error`  — warning tone; something broke (fetch failed, etc.).
+ */
+export function EmptyState({ variant, title, body, action }: Props) {
+  const isError = variant === 'error'
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center p-8 text-center gap-3 ${
+        isError
+          ? 'border border-status-critical bg-[rgba(231,76,60,0.05)]'
+          : ''
+      }`}
+      style={{ minHeight: 200 }}
+      role={isError ? 'alert' : undefined}
+    >
+      {/* Accent line */}
+      <div
+        className="w-8 h-px"
+        style={{
+          background: isError ? 'var(--status-critical)' : 'var(--border-subtle)',
+        }}
+      />
+
+      {/* Title */}
+      <div
+        className={`font-mono text-2xs uppercase tracking-[0.12em] ${
+          isError ? 'text-status-critical' : 'text-text-tertiary'
+        }`}
+      >
+        {title}
+      </div>
+
+      {/* Body */}
+      {body && (
+        <p
+          className={`font-serif italic text-sm leading-relaxed max-w-[240px] ${
+            isError ? 'text-status-critical opacity-70' : 'text-text-tertiary'
+          }`}
+        >
+          {body}
+        </p>
+      )}
+
+      {/* Optional action (e.g. a Reload button) */}
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  )
+}

--- a/components/game/GameErrorBoundary.tsx
+++ b/components/game/GameErrorBoundary.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { Component, type ReactNode, type ErrorInfo } from 'react'
+
+interface Props {
+  children: ReactNode
+  /** Custom fallback renderer. Receives the caught error + a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+/**
+ * React error boundary for the GameView subtree.
+ *
+ * Catches runtime errors (hydration failures, unhandled component crashes)
+ * and renders a fallback UI instead of a white-screen crash.
+ *
+ * Usage:
+ *   <GameErrorBoundary>
+ *     <GameView ... />
+ *   </GameErrorBoundary>
+ *
+ * Or with a custom fallback:
+ *   <GameErrorBoundary fallback={(err, reset) => <MyFallback err={err} onReset={reset} />}>
+ *     ...
+ *   </GameErrorBoundary>
+ */
+export class GameErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { error: null }
+    this.reset = this.reset.bind(this)
+  }
+
+  static getDerivedStateFromError(error: unknown): State {
+    return { error: error instanceof Error ? error : new Error(String(error)) }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Non-invasive logging — no external service required.
+    console.error('[GameErrorBoundary] Caught unhandled error:', error, info.componentStack)
+  }
+
+  reset() {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+    const { children, fallback } = this.props
+
+    if (error) {
+      if (fallback) {
+        return fallback(error, this.reset)
+      }
+
+      // Default fallback — "Declassified War Room" tone, Stitch design tokens
+      return (
+        <div
+          className="flex flex-col items-center justify-center w-full h-full min-h-[320px] gap-4 p-8 text-center"
+          style={{ background: 'var(--bg-base)' }}
+          role="alert"
+        >
+          {/* Red accent rule */}
+          <div className="w-10 h-px" style={{ background: 'var(--status-critical)' }} />
+
+          <div className="font-mono text-2xs uppercase tracking-[0.18em] text-status-critical">
+            SYSTEM FAULT DETECTED
+          </div>
+
+          <p className="font-serif italic text-sm text-text-tertiary leading-relaxed max-w-[320px]">
+            An unhandled error has disrupted the simulation display. Your session state
+            is intact — reload the panel to continue operations.
+          </p>
+
+          {/* Error detail (collapsed, dev-friendly) */}
+          <details className="w-full max-w-sm text-left">
+            <summary className="font-mono text-[9px] uppercase tracking-[0.12em] text-text-tertiary cursor-pointer hover:text-text-secondary">
+              Error details
+            </summary>
+            <pre className="mt-2 px-3 py-2 font-mono text-[9px] text-status-critical bg-bg-surface border border-status-critical overflow-auto whitespace-pre-wrap break-all">
+              {error.message}
+            </pre>
+          </details>
+
+          <button
+            onClick={this.reset}
+            className="mt-2 px-6 py-2 font-mono text-[11px] font-semibold uppercase tracking-[0.1em] border border-gold text-gold hover:bg-gold hover:text-bg-base transition-colors"
+          >
+            RELOAD PANEL →
+          </button>
+        </div>
+      )
+    }
+
+    return children
+  }
+}

--- a/components/game/GameView.tsx
+++ b/components/game/GameView.tsx
@@ -20,6 +20,8 @@ import { ActorControlSelector } from '@/components/game/ActorControlSelector'
 import { DispatchTerminal } from '@/components/game/DispatchTerminal'
 import { ObserverOverlay } from '@/components/panels/ObserverOverlay'
 import { TurnPhaseIndicator } from '@/components/game/TurnPhaseIndicator'
+import { GameErrorBoundary } from '@/components/game/GameErrorBoundary'
+import { EmptyState } from '@/components/game/EmptyState'
 import { ProgressBar } from '@/components/ui/ProgressBar'
 import { Tooltip } from '@/components/ui/Tooltip'
 import type { ActorSummary, ActorDetail, DecisionDetail, ActionSlot } from '@/lib/types/panels'
@@ -67,6 +69,16 @@ function ActorsPanel({
   viewerActorId: string | null
   onSelect: (id: string) => void
 }) {
+  if (actors.length === 0) {
+    return (
+      <EmptyState
+        variant="empty"
+        title="No Actors"
+        body="Actor data has not loaded yet. Refresh or wait for the scenario to initialise."
+      />
+    )
+  }
+
   return (
     <div className="flex flex-col">
       <div className="flex flex-col divide-y divide-border-subtle">
@@ -744,6 +756,7 @@ export function GameView({ branchId, scenarioId, initialData }: Props) {
   }
 
   return (
+    <GameErrorBoundary>
     <>
       <GameLayout
         mapContent={mapContent}
@@ -823,5 +836,6 @@ export function GameView({ branchId, scenarioId, initialData }: Props) {
         onToggleOmniscient={() => setOmniscientMode(prev => !prev)}
       />
     </>
+    </GameErrorBoundary>
   )
 }

--- a/components/map/GameMap.tsx
+++ b/components/map/GameMap.tsx
@@ -83,25 +83,36 @@ export function GameMap({ globalState, scenarioId = 'iran-2026', branchId = '', 
   const [mapAssetSelection, setMapAssetSelection] = useState<MapAssetSelection | null>(null)
   const [chokepointPopup, setChokepointPopup] = useState<ChokepointInfo | null>(null)
   const [staticFeaturePopup, setStaticFeaturePopup] = useState<StaticFeatureClickInfo | null>(null)
+  const [fetchError, setFetchError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!branchId || !turnCommitId) return
     const url = `/api/scenarios/${scenarioId}/branches/${branchId}/map-assets?turnCommitId=${turnCommitId}`
     fetch(url)
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) throw new Error(`map-assets: ${r.status}`)
+        return r.json()
+      })
       .then(({ data }: { data: { assets?: MapAsset[]; shipping_lanes?: ShippingLane[] } | null }) => {
-        if (data?.assets)        setMapAssets(data.assets)
+        if (data?.assets)         setMapAssets(data.assets)
         if (data?.shipping_lanes) setShippingLanes(data.shipping_lanes)
       })
-      .catch(() => {})
+      .catch((err: unknown) => {
+        setFetchError(err instanceof Error ? err.message : 'Failed to load map assets')
+      })
   }, [scenarioId, branchId, turnCommitId])
 
   useEffect(() => {
     if (!scenarioId) return
     fetch(`/api/scenarios/${scenarioId}/cities`)
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) throw new Error(`cities: ${r.status}`)
+        return r.json()
+      })
       .then(({ data }: { data: City[] | null }) => { if (data) setCities(data) })
-      .catch(() => {})
+      .catch((err: unknown) => {
+        setFetchError(err instanceof Error ? err.message : 'Failed to load city data')
+      })
   }, [scenarioId])
 
   function handleAssetClick(asset: PositionedAsset) {
@@ -382,6 +393,30 @@ export function GameMap({ globalState, scenarioId = 'iran-2026', branchId = '', 
       >
         24°N 56°E // PERSIAN GULF THEATER
       </div>
+
+      {/* ── Network failure banner ── */}
+      {fetchError && (
+        <div
+          className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between gap-3 px-4 py-2 font-mono text-[9px] uppercase tracking-[0.1em] border-b"
+          style={{
+            background: 'rgba(231,76,60,0.12)',
+            borderColor: 'var(--status-critical)',
+            color: 'var(--status-critical)',
+          }}
+          role="alert"
+        >
+          <span>
+            ● ASSET FETCH FAILED — {fetchError}. Map data may be incomplete.
+          </span>
+          <button
+            onClick={() => setFetchError(null)}
+            className="shrink-0 hover:opacity-80 transition-opacity"
+            aria-label="Dismiss error"
+          >
+            ✕
+          </button>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **GameErrorBoundary** (`components/game/GameErrorBoundary.tsx`) — React class component with `getDerivedStateFromError` + `componentDidCatch`. Renders a "SYSTEM FAULT DETECTED" fallback (Stitch design tokens, gold CTA reload button) instead of a white screen. Accepts an optional `fallback` render-prop for custom overrides.
- **EmptyState** (`components/game/EmptyState.tsx`) — shared functional component with two visually distinct variants:
  - `empty` — neutral tone, subtle border, `text-text-tertiary`; for valid/expected no-data states.
  - `error` — red/critical tone, `border-status-critical` + tinted background; for fetch failures and broken states.
- **GameView** — imports both new components; wraps the main return in `<GameErrorBoundary>`; inline `ActorsPanel` renders `<EmptyState variant="empty">` when `actors.length === 0`.
- **ChronicleTimeline** — replaces ad-hoc inline empty div with `<EmptyState variant="empty">`; adds `fetchError?: boolean` prop that renders `<EmptyState variant="error">`.
- **GameMap** — tracks network failures for `map-assets` and `cities` fetches; shows a dismissible top-of-map banner (`role="alert"`, red accent) on non-200 responses.

## Test plan

- [ ] Typecheck: `npm run typecheck` — clean (no errors)
- [ ] Lint: `npm run lint` — clean (pre-existing MapboxMap ref warnings only, not introduced here)
- [ ] Manually trigger `actors.length === 0` path (pass empty actors array) — empty state renders with neutral styling
- [ ] Simulate a fetch 500 from `map-assets` — red banner appears above map, dismisses on ✕
- [ ] Throw a deliberate render error inside GameView — GameErrorBoundary fallback shows with Reload button; clicking reset recovers
- [ ] Chronicle with `fetchError={true}` — red EmptyState renders; without it and empty entries — neutral EmptyState renders

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)