### PR TITLE
feat(ai): add prompt caching to stable actor/resolution/judge prompts

### DIFF
--- a/lib/ai/actor-agent-runner.ts
+++ b/lib/ai/actor-agent-runner.ts
@@ -6,7 +6,7 @@
 
 import { callClaude } from '@/lib/ai/anthropic'
 import {
-  NEUTRALITY_PREAMBLE,
+  buildCachedSystemBlocks,
   buildActorProfileBlock,
   buildLiveScoreBlock,
   buildGlobalStateBlock,
@@ -43,9 +43,11 @@ export interface ActorAgentOutput {
   rationale: string
 }
 
-const ACTOR_AGENT_SYSTEM = `${NEUTRALITY_PREAMBLE}
-
-ROLE: You are the strategic decision-making agent for a specific actor in the simulation.
+/**
+ * Stable role text for the actor agent — does NOT include NEUTRALITY_PREAMBLE
+ * (that is block 1 in buildCachedSystemBlocks). Must never contain per-turn data.
+ */
+const ACTOR_AGENT_ROLE_TEXT = `ROLE: You are the strategic decision-making agent for a specific actor in the simulation.
 Your job is to select the BEST turn plan from available decisions, reasoning from the actor's
 own strategic perspective, objectives, and constraints.
 
@@ -71,6 +73,8 @@ OUTPUT FORMAT — return ONLY this JSON:
   ],
   "rationale": string  // 2-3 sentences explaining the strategic logic
 }`
+
+const ACTOR_AGENT_SYSTEM_BLOCKS = buildCachedSystemBlocks(ACTOR_AGENT_ROLE_TEXT)
 
 export async function runActorAgent(input: ActorAgentInput): Promise<ActorAgentOutput> {
   const {
@@ -116,7 +120,10 @@ ${decisionsBlock}
 
 Select your turn plan. Return the JSON specified in your instructions.`
 
-  const raw = await callClaude(ACTOR_AGENT_SYSTEM, userPrompt, { maxTokens: 2048 })
+  const raw = await callClaude('', userPrompt, {
+    maxTokens: 2048,
+    systemBlocks: ACTOR_AGENT_SYSTEM_BLOCKS,
+  })
 
   const parsed = raw as {
     primaryActionDecisionId: string

--- a/lib/ai/anthropic.ts
+++ b/lib/ai/anthropic.ts
@@ -12,12 +12,27 @@ function getClient(): Anthropic {
 export interface CallClaudeOptions {
   tools?: unknown[];
   maxTokens?: number;
+  /**
+   * Pre-built system content blocks with cache_control markers already applied.
+   * When provided, overrides the automatic single-block wrapping of `systemPrompt`.
+   * Use `buildCachedSystemBlocks()` from lib/ai/prompts to construct the two-block
+   * array that places separate ephemeral breakpoints on the NEUTRALITY_PREAMBLE
+   * and on the agent-specific role instructions.
+   */
+  systemBlocks?: Anthropic.Messages.TextBlockParam[];
 }
 
 /**
  * Call Claude with prompt caching enabled on the system prompt.
- * The system prompt is sent as a single ephemeral-cached text block,
- * which caches the stable NEUTRALITY_PREAMBLE prefix across pipeline calls.
+ *
+ * Two caching modes:
+ *  - Default (no `systemBlocks`): the entire `systemPrompt` string is wrapped in a
+ *    single cached text block (backward-compatible, single breakpoint).
+ *  - Structured (`systemBlocks` provided): the caller supplies pre-built content
+ *    blocks with `cache_control` markers. Use this to place two separate breakpoints —
+ *    one on the shared NEUTRALITY_PREAMBLE and one on agent-specific role text —
+ *    maximising cache reuse across the pipeline.
+ *
  * Returns the parsed JSON from the last text block in the response.
  */
 export async function callClaude(
@@ -25,18 +40,20 @@ export async function callClaude(
   userPrompt: string,
   options: CallClaudeOptions = {}
 ): Promise<unknown> {
-  const { tools, maxTokens = 8192 } = options;
+  const { tools, maxTokens = 8192, systemBlocks } = options;
+
+  const systemParam: Anthropic.Messages.TextBlockParam[] = systemBlocks ?? [
+    {
+      type: "text" as const,
+      text: systemPrompt,
+      cache_control: { type: "ephemeral" as const },
+    },
+  ];
 
   const response = await getClient().messages.create({
     model: "claude-sonnet-4-6",
     max_tokens: maxTokens,
-    system: [
-      {
-        type: "text" as const,
-        text: systemPrompt,
-        cache_control: { type: "ephemeral" as const },
-      },
-    ],
+    system: systemParam,
     messages: [{ role: "user", content: userPrompt }],
     ...(tools && tools.length > 0
       ? { tools: tools as Anthropic.Messages.Tool[] }

--- a/lib/ai/judge-evaluator.ts
+++ b/lib/ai/judge-evaluator.ts
@@ -5,7 +5,7 @@
  */
 
 import { callClaude } from '@/lib/ai/anthropic'
-import { NEUTRALITY_PREAMBLE } from '@/lib/ai/prompts'
+import { buildCachedSystemBlocks } from '@/lib/ai/prompts'
 import type { TurnPlan, EventStateEffects } from '@/lib/types/simulation'
 
 export const JUDGE_THRESHOLD = 40
@@ -30,9 +30,11 @@ export interface JudgeOutput {
   verdict: 'accept' | 'retry'
 }
 
-const JUDGE_SYSTEM = `${NEUTRALITY_PREAMBLE}
-
-ROLE: You are the Judge — an evaluator of strategic plausibility. You review the
+/**
+ * Stable role text for the judge — does NOT include NEUTRALITY_PREAMBLE.
+ * Must never contain per-turn data.
+ */
+const JUDGE_ROLE_TEXT = `ROLE: You are the Judge — an evaluator of strategic plausibility. You review the
 actions taken and the resolution outcomes and score whether they are realistic,
 historically grounded, and internally consistent.
 
@@ -63,6 +65,8 @@ OUTPUT FORMAT — return ONLY this JSON:
   "critique": string,
   "verdict": "accept" | "retry"
 }`
+
+const JUDGE_SYSTEM_BLOCKS = buildCachedSystemBlocks(JUDGE_ROLE_TEXT)
 
 /**
  * Score a single resolution attempt. Returns score, critique, and verdict.
@@ -105,7 +109,10 @@ ${effectsBlock}
 
 Score the plausibility of this turn resolution.`
 
-  const raw = await callClaude(JUDGE_SYSTEM, userPrompt, { maxTokens: 1024 })
+  const raw = await callClaude('', userPrompt, {
+    maxTokens: 1024,
+    systemBlocks: JUDGE_SYSTEM_BLOCKS,
+  })
 
   const parsed = raw as {
     score: number

--- a/lib/ai/narrator.ts
+++ b/lib/ai/narrator.ts
@@ -5,7 +5,7 @@
  */
 
 import { callClaude } from '@/lib/ai/anthropic'
-import { NEUTRALITY_PREAMBLE } from '@/lib/ai/prompts'
+import { buildCachedSystemBlocks } from '@/lib/ai/prompts'
 import type { TurnPlan, EventStateEffects } from '@/lib/types/simulation'
 
 export interface NarratorInput {
@@ -36,9 +36,11 @@ export interface NarratorOutput {
   fullBriefing: string
 }
 
-const NARRATOR_SYSTEM = `${NEUTRALITY_PREAMBLE}
-
-ROLE: You are the War Chronicle narrator — an analytical journalist writing for a classified
+/**
+ * Stable role text for the narrator — does NOT include NEUTRALITY_PREAMBLE.
+ * Must never contain per-turn data.
+ */
+const NARRATOR_ROLE_TEXT = `ROLE: You are the War Chronicle narrator — an analytical journalist writing for a classified
 strategic intelligence audience. Your prose should be clear, authoritative, and deeply analytical.
 Think: combination of The Economist, a classified ODNI assessment, and a thriller novel.
 
@@ -56,6 +58,8 @@ OUTPUT FORMAT — return ONLY this JSON:
   "chronicle_headline": string,
   "full_briefing": string
 }`
+
+const NARRATOR_SYSTEM_BLOCKS = buildCachedSystemBlocks(NARRATOR_ROLE_TEXT)
 
 export async function runNarrator(input: NarratorInput): Promise<NarratorOutput> {
   const {
@@ -123,7 +127,10 @@ JUDGE ASSESSMENT (${judgeScore}/100): ${judgeCritique}
 
 Write the War Chronicle entry for this turn.`
 
-  const raw = await callClaude(NARRATOR_SYSTEM, userPrompt, { maxTokens: 3000 })
+  const raw = await callClaude('', userPrompt, {
+    maxTokens: 3000,
+    systemBlocks: NARRATOR_SYSTEM_BLOCKS,
+  })
 
   const parsed = raw as {
     chronicle_headline: string

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -4,6 +4,8 @@
  * across all agent calls to reduce token cost via Anthropic prompt caching.
  */
 
+import type Anthropic from '@anthropic-ai/sdk'
+
 export const NEUTRALITY_PREAMBLE = `You are an analyst for the War Game strategic simulation engine.
 War Game models complex competitive dynamics between nation-states and actors with
 absolute analytical neutrality. Your role is to reason rigorously from each actor's
@@ -82,6 +84,40 @@ export function buildGlobalStateBlock(global: {
   Oil price: $${global.oil_price_usd}/barrel
   Strait of Hormuz throughput: ${global.hormuz_throughput_pct}% of normal
   Global economic stress index: ${global.global_economic_stress}/100`
+}
+
+/**
+ * Build two separately-cached system content blocks for any agent call.
+ *
+ * Per the Anthropic prompt caching spec, placing `cache_control: { type: 'ephemeral' }`
+ * on the LAST block of each stable section creates a cumulative cache breakpoint.
+ * With two blocks the API stores two breakpoints:
+ *
+ *   Block 1 (NEUTRALITY_PREAMBLE) — shared across ALL agents; cached once per session.
+ *   Block 2 (agent role text)     — stable per agent type; cached once per agent type.
+ *
+ * Turn-variable data (current state, simulated date, turn number, divergence count,
+ * live scores) must NEVER be included in either block — it goes in the user message.
+ *
+ * @param agentRoleText The stable, agent-specific ROLE + OUTPUT FORMAT instructions.
+ *   Must not contain per-turn data.
+ * @returns An array of two TextBlockParam objects, each with cache_control applied.
+ */
+export function buildCachedSystemBlocks(
+  agentRoleText: string
+): Anthropic.Messages.TextBlockParam[] {
+  return [
+    {
+      type: 'text' as const,
+      text: NEUTRALITY_PREAMBLE,
+      cache_control: { type: 'ephemeral' as const },
+    },
+    {
+      type: 'text' as const,
+      text: agentRoleText,
+      cache_control: { type: 'ephemeral' as const },
+    },
+  ]
 }
 
 /**

--- a/lib/ai/resolution-engine.ts
+++ b/lib/ai/resolution-engine.ts
@@ -5,7 +5,7 @@
  */
 
 import { callClaude } from '@/lib/ai/anthropic'
-import { NEUTRALITY_PREAMBLE, buildGlobalStateBlock } from '@/lib/ai/prompts'
+import { buildCachedSystemBlocks, buildGlobalStateBlock } from '@/lib/ai/prompts'
 import type { TurnPlan, EventStateEffects, BranchStateAtTurn, Decision } from '@/lib/types/simulation'
 
 export interface ResolutionInput {
@@ -39,9 +39,11 @@ export interface ResolutionOutput {
   narrativeSummary: string
 }
 
-const RESOLUTION_SYSTEM = `${NEUTRALITY_PREAMBLE}
-
-ROLE: You are the omniscient resolution engine. You see ALL actor plans simultaneously
+/**
+ * Stable role text for the resolution engine — does NOT include NEUTRALITY_PREAMBLE.
+ * Must never contain per-turn data.
+ */
+const RESOLUTION_ROLE_TEXT = `ROLE: You are the omniscient resolution engine. You see ALL actor plans simultaneously
 and resolve their simultaneous execution. Your job is to determine realistic outcomes
 when multiple actors execute their strategies at the same time.
 
@@ -111,6 +113,8 @@ OUTPUT FORMAT — return ONLY this JSON:
   "narrative_summary": string
 }`
 
+const RESOLUTION_SYSTEM_BLOCKS = buildCachedSystemBlocks(RESOLUTION_ROLE_TEXT)
+
 export async function runResolutionEngine(input: ResolutionInput): Promise<ResolutionOutput> {
   const {
     turnPlans,
@@ -163,7 +167,10 @@ ${plansBlock}
 ${correctionBlock}
 Resolve all simultaneous actions and return the JSON effects object.`
 
-  const raw = await callClaude(RESOLUTION_SYSTEM, userPrompt, { maxTokens: 4096 })
+  const raw = await callClaude('', userPrompt, {
+    maxTokens: 4096,
+    systemBlocks: RESOLUTION_SYSTEM_BLOCKS,
+  })
 
   const parsed = raw as {
     actor_score_deltas: Record<string, Record<string, number>>

--- a/tests/ai/actor-agent-caching.test.ts
+++ b/tests/ai/actor-agent-caching.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests that prompt caching is correctly applied to stable sections of each
+ * AI agent system prompt, without caching turn-variable data.
+ *
+ * Implementation note: these tests mock @anthropic-ai/sdk at the module level,
+ * capture the `system` array passed to messages.create, and assert that:
+ *  1. At least one block has cache_control: { type: 'ephemeral' }.
+ *  2. Exactly two blocks are cached (NEUTRALITY_PREAMBLE + role-specific).
+ *  3. Turn-variable data (date, turn number, live scores) is NOT in any cached block.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type Anthropic from '@anthropic-ai/sdk'
+
+// ---- captured call store (module-level so the hoisted mock can write to it) ---
+const capturedCalls: Array<{
+  system: Anthropic.Messages.TextBlockParam[]
+  userContent: string
+}> = []
+
+// vi.mock is hoisted to the top of the file by Vitest — the factory runs before
+// any imports, so capturedCalls must be defined before this call.
+vi.mock('@anthropic-ai/sdk', () => {
+  const mockCreate = vi.fn(async (params: Anthropic.Messages.MessageCreateParamsNonStreaming) => {
+    const systemBlocks = Array.isArray(params.system)
+      ? (params.system as Anthropic.Messages.TextBlockParam[])
+      : []
+    const userContent =
+      typeof params.messages?.[0]?.content === 'string'
+        ? (params.messages[0].content as string)
+        : ''
+
+    capturedCalls.push({ system: systemBlocks, userContent })
+
+    // Default response shape — works for actor agent.
+    // Individual tests that call other agents override `text` content.
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            // actor agent fields
+            primaryActionDecisionId: 'test-decision',
+            primaryActionProfile: null,
+            primaryActionResourcePercent: 100,
+            concurrentActions: [],
+            rationale: 'test rationale',
+            // resolution engine fields
+            actor_score_deltas: {},
+            asset_inventory_deltas: {},
+            global_state_deltas: { oil_price_usd: 0, hormuz_throughput_pct: 0, global_economic_stress: 0 },
+            facility_updates: [],
+            new_depletion_rates: [],
+            headline: 'Test headline',
+            escalation_changes: [],
+            narrative_summary: 'Test summary',
+            // judge fields
+            score: 75,
+            critique: 'Looks good.',
+            verdict: 'accept',
+            rationale_breakdown: {
+              actor_rationality: 20,
+              resolution_realism: 20,
+              historical_grounding: 15,
+              internal_consistency: 20,
+            },
+            // narrator fields
+            chronicle_headline: 'Test headline',
+            full_briefing: 'Test briefing.',
+          }),
+        },
+      ],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 0,
+      },
+    }
+  })
+
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      messages: { create: mockCreate },
+    })),
+  }
+})
+
+// ---- fixtures ----------------------------------------------------------
+
+function makeActorProfile() {
+  return {
+    id: 'united_states',
+    name: 'United States',
+    short_name: 'US',
+    biographical_summary: 'The primary Western superpower.',
+    leadership_profile: 'Presidential democracy.',
+    win_condition: 'Prevent Iranian nuclear capability.',
+    strategic_doctrine: 'Forward deterrence and alliance management.',
+    historical_precedents: 'Desert Storm, Iraqi Freedom.',
+    initial_scores: { military_strength: 95, political_stability: 75 },
+  }
+}
+
+function makeBranchState() {
+  return {
+    actor_states: {
+      united_states: {
+        military_strength: 90,
+        political_stability: 70,
+        economic_health: 80,
+        public_support: 60,
+        international_standing: 75,
+        asset_availability: {},
+        facility_statuses: [],
+      },
+    },
+    global_state: {
+      oil_price_usd: 85,
+      hormuz_throughput_pct: 100,
+      global_economic_stress: 30,
+    },
+  }
+}
+
+function makeDecisions() {
+  return [
+    {
+      id: 'diplomatic-engagement',
+      name: 'Diplomatic Engagement',
+      description: 'Pursue diplomatic channels.',
+      dimension: 'diplomatic',
+      escalationLevel: 1,
+    },
+  ]
+}
+
+// ---- Actor Agent tests -------------------------------------------------
+
+describe('Actor Agent prompt caching', () => {
+  beforeEach(() => { capturedCalls.length = 0 })
+
+  it('sends system prompt as an array of content blocks', async () => {
+    const { runActorAgent } = await import('@/lib/ai/actor-agent-runner')
+    await runActorAgent({
+      actorId: 'united_states',
+      actorProfile: makeActorProfile(),
+      branchState: makeBranchState() as unknown as Parameters<typeof runActorAgent>[0]['branchState'],
+      availableDecisions: makeDecisions() as unknown as Parameters<typeof runActorAgent>[0]['availableDecisions'],
+      branchDivergence: 0,
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+    })
+
+    expect(capturedCalls.length).toBeGreaterThan(0)
+    expect(Array.isArray(capturedCalls[0].system)).toBe(true)
+    expect(capturedCalls[0].system.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('has cache_control: { type: "ephemeral" } on at least one system block', async () => {
+    const { runActorAgent } = await import('@/lib/ai/actor-agent-runner')
+    await runActorAgent({
+      actorId: 'united_states',
+      actorProfile: makeActorProfile(),
+      branchState: makeBranchState() as unknown as Parameters<typeof runActorAgent>[0]['branchState'],
+      availableDecisions: makeDecisions() as unknown as Parameters<typeof runActorAgent>[0]['availableDecisions'],
+      branchDivergence: 0,
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+    })
+
+    const cachedBlocks = capturedCalls[0].system.filter(
+      b => b.cache_control?.type === 'ephemeral'
+    )
+    expect(cachedBlocks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('has exactly two cache_control breakpoints — preamble and role-specific block', async () => {
+    const { runActorAgent } = await import('@/lib/ai/actor-agent-runner')
+    await runActorAgent({
+      actorId: 'united_states',
+      actorProfile: makeActorProfile(),
+      branchState: makeBranchState() as unknown as Parameters<typeof runActorAgent>[0]['branchState'],
+      availableDecisions: makeDecisions() as unknown as Parameters<typeof runActorAgent>[0]['availableDecisions'],
+      branchDivergence: 0,
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+    })
+
+    const cachedBlocks = capturedCalls[0].system.filter(
+      b => b.cache_control?.type === 'ephemeral'
+    )
+    expect(cachedBlocks.length).toBe(2)
+  })
+
+  it('does NOT include turn-variable data in any cached block', async () => {
+    const { runActorAgent } = await import('@/lib/ai/actor-agent-runner')
+    const simulatedDate = '2026-03-15'
+    const turnNumber = 7
+    await runActorAgent({
+      actorId: 'united_states',
+      actorProfile: makeActorProfile(),
+      branchState: makeBranchState() as unknown as Parameters<typeof runActorAgent>[0]['branchState'],
+      availableDecisions: makeDecisions() as unknown as Parameters<typeof runActorAgent>[0]['availableDecisions'],
+      branchDivergence: 2,
+      simulatedDate,
+      turnNumber,
+    })
+
+    const cachedText = capturedCalls[0].system
+      .filter(b => b.cache_control?.type === 'ephemeral')
+      .map(b => b.text)
+      .join('\n')
+
+    // These values change every turn — must NOT be in cached blocks
+    expect(cachedText).not.toContain(simulatedDate)
+    expect(cachedText).not.toContain(`Turn ${turnNumber}`)
+    expect(cachedText).not.toContain('Military Strength:')
+    expect(cachedText).not.toContain('Branch diverged')
+
+    // They should appear in the user message instead
+    expect(capturedCalls[0].userContent).toContain(simulatedDate)
+    expect(capturedCalls[0].userContent).toContain(`Turn ${turnNumber}`)
+  })
+
+  it('NEUTRALITY_PREAMBLE text appears in the first cached system block', async () => {
+    const { runActorAgent } = await import('@/lib/ai/actor-agent-runner')
+    const { NEUTRALITY_PREAMBLE } = await import('@/lib/ai/prompts')
+    await runActorAgent({
+      actorId: 'united_states',
+      actorProfile: makeActorProfile(),
+      branchState: makeBranchState() as unknown as Parameters<typeof runActorAgent>[0]['branchState'],
+      availableDecisions: makeDecisions() as unknown as Parameters<typeof runActorAgent>[0]['availableDecisions'],
+      branchDivergence: 0,
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+    })
+
+    const firstCachedBlock = capturedCalls[0].system.find(
+      b => b.cache_control?.type === 'ephemeral'
+    )
+    expect(firstCachedBlock).toBeDefined()
+    // The first cached block must contain the preamble (or start of it)
+    const preambleStart = NEUTRALITY_PREAMBLE.slice(0, 60)
+    expect(firstCachedBlock!.text).toContain(preambleStart)
+  })
+})
+
+// ---- Resolution Engine tests ------------------------------------------
+
+describe('Resolution Engine prompt caching', () => {
+  beforeEach(() => { capturedCalls.length = 0 })
+
+  it('has exactly two cache_control breakpoints', async () => {
+    const { runResolutionEngine } = await import('@/lib/ai/resolution-engine')
+    await runResolutionEngine({
+      turnPlans: [],
+      branchState: makeBranchState() as unknown as Parameters<typeof runResolutionEngine>[0]['branchState'],
+      decisionCatalog: [],
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+      scenarioContext: 'Test scenario',
+    })
+
+    expect(capturedCalls.length).toBeGreaterThan(0)
+    const cachedBlocks = capturedCalls[0].system.filter(
+      b => b.cache_control?.type === 'ephemeral'
+    )
+    expect(cachedBlocks.length).toBe(2)
+  })
+
+  it('turn-variable data is NOT in any cached block', async () => {
+    const { runResolutionEngine } = await import('@/lib/ai/resolution-engine')
+    const simulatedDate = '2026-06-01'
+    const turnNumber = 5
+    await runResolutionEngine({
+      turnPlans: [],
+      branchState: makeBranchState() as unknown as Parameters<typeof runResolutionEngine>[0]['branchState'],
+      decisionCatalog: [],
+      simulatedDate,
+      turnNumber,
+      scenarioContext: 'Test scenario',
+    })
+
+    const cachedText = capturedCalls[0].system
+      .filter(b => b.cache_control?.type === 'ephemeral')
+      .map(b => b.text)
+      .join('\n')
+
+    expect(cachedText).not.toContain(simulatedDate)
+    expect(cachedText).not.toContain(`Turn ${turnNumber}`)
+  })
+})
+
+// ---- Judge Evaluator tests --------------------------------------------
+
+describe('Judge Evaluator prompt caching', () => {
+  beforeEach(() => { capturedCalls.length = 0 })
+
+  it('has exactly two cache_control breakpoints', async () => {
+    const { runJudge } = await import('@/lib/ai/judge-evaluator')
+    await runJudge({
+      turnPlans: [],
+      effects: {
+        actor_score_deltas: {},
+        asset_inventory_deltas: {},
+        global_state_deltas: {},
+        facility_updates: [],
+        new_depletion_rates: [],
+      },
+      headline: 'Test',
+      narrativeSummary: 'Summary',
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+      scenarioContext: 'Test scenario',
+    })
+
+    expect(capturedCalls.length).toBeGreaterThan(0)
+    const cachedBlocks = capturedCalls[0].system.filter(
+      b => b.cache_control?.type === 'ephemeral'
+    )
+    expect(cachedBlocks.length).toBe(2)
+  })
+
+  it('turn-variable data is NOT in any cached block', async () => {
+    const { runJudge } = await import('@/lib/ai/judge-evaluator')
+    const simulatedDate = '2026-09-15'
+    const turnNumber = 12
+    await runJudge({
+      turnPlans: [],
+      effects: {
+        actor_score_deltas: {},
+        asset_inventory_deltas: {},
+        global_state_deltas: {},
+        facility_updates: [],
+        new_depletion_rates: [],
+      },
+      headline: 'Test',
+      narrativeSummary: 'Summary',
+      simulatedDate,
+      turnNumber,
+      scenarioContext: 'Test scenario',
+    })
+
+    const cachedText = capturedCalls[0].system
+      .filter(b => b.cache_control?.type === 'ephemeral')
+      .map(b => b.text)
+      .join('\n')
+    expect(cachedText).not.toContain(simulatedDate)
+    expect(cachedText).not.toContain(`Turn ${turnNumber}`)
+  })
+})
+
+// ---- Narrator tests ---------------------------------------------------
+
+describe('Narrator prompt caching', () => {
+  beforeEach(() => { capturedCalls.length = 0 })
+
+  it('has exactly two cache_control breakpoints', async () => {
+    const { runNarrator } = await import('@/lib/ai/narrator')
+    await runNarrator({
+      turnPlans: [],
+      effects: {
+        actor_score_deltas: {},
+        asset_inventory_deltas: {},
+        global_state_deltas: {},
+        facility_updates: [],
+        new_depletion_rates: [],
+      },
+      headline: 'Test',
+      narrativeSummary: 'Summary',
+      judgeScore: 80,
+      judgeCritique: 'Good.',
+      simulatedDate: '2026-01-01',
+      turnNumber: 1,
+      scenarioContext: 'Test scenario',
+      escalationChanges: [],
+    })
+
+    expect(capturedCalls.length).toBeGreaterThan(0)
+    const cachedBlocks = capturedCalls[0].system.filter(
+      b => b.cache_control?.type === 'ephemeral'
+    )
+    expect(cachedBlocks.length).toBe(2)
+  })
+
+  it('turn-variable data is NOT in any cached block', async () => {
+    const { runNarrator } = await import('@/lib/ai/narrator')
+    const simulatedDate = '2026-12-01'
+    const turnNumber = 20
+    await runNarrator({
+      turnPlans: [],
+      effects: {
+        actor_score_deltas: {},
+        asset_inventory_deltas: {},
+        global_state_deltas: {},
+        facility_updates: [],
+        new_depletion_rates: [],
+      },
+      headline: 'Test',
+      narrativeSummary: 'Summary',
+      judgeScore: 60,
+      judgeCritique: 'Acceptable.',
+      simulatedDate,
+      turnNumber,
+      scenarioContext: 'Test scenario',
+      escalationChanges: [],
+    })
+
+    const cachedText = capturedCalls[0].system
+      .filter(b => b.cache_control?.type === 'ephemeral')
+      .map(b => b.text)
+      .join('\n')
+    expect(cachedText).not.toContain(simulatedDate)
+    expect(cachedText).not.toContain(`Turn ${turnNumber}`)
+  })
+})


### PR DESCRIPTION
## Summary

- Add two-breakpoint `cache_control: { type: 'ephemeral' }` structure to all four AI pipeline agents (actor agent, resolution engine, judge, narrator)
- Extract a `buildCachedSystemBlocks()` helper in `lib/ai/prompts.ts` that splits `NEUTRALITY_PREAMBLE` (block 1, shared across all agents) from agent-specific role text (block 2) — each block gets its own cache breakpoint
- Add `systemBlocks` option to `callClaude()` in `lib/ai/anthropic.ts` for passing pre-built cached content blocks (backward compatible with existing single-block callers)
- Write 11 tests in `tests/ai/actor-agent-caching.test.ts` verifying cache placement without hitting the real API

## Cache strategy

Per [Anthropic prompt caching docs](https://docs.claude.com/en/docs/build-with-claude/prompt-caching), placing `cache_control: { type: 'ephemeral' }` on the **last block of each stable section** creates cumulative breakpoints:

| Block | Content | Cache scope |
|-------|---------|-------------|
| 1 | `NEUTRALITY_PREAMBLE` (shared across ALL agents) | Cached once per session — hit on every subsequent agent call |
| 2 | Agent-specific role text (DECISION RULES, OUTPUT FORMAT, etc.) | Cached once per agent type — stable within a game session |

Turn-variable data (simulated date, turn number, live scores, branch divergence, actor plans) is **never** in a cached block — it goes in the user message.

## Test plan

- [x] `npm test -- --run tests/ai/` — 11/11 pass
- [x] `npm run typecheck` — clean (0 errors)
- [x] Full suite: same 4 pre-existing failures as before (middleware, research-pipeline, seed-iran, TurnPlanBuilder) — no regressions

## Self-review: cache_control on STABLE content only?

- Block 1: `NEUTRALITY_PREAMBLE` constant — never changes. ✅
- Block 2: agent role text (`ACTOR_AGENT_ROLE_TEXT`, `RESOLUTION_ROLE_TEXT`, etc.) — compile-time constants with no dynamic interpolation. ✅
- Turn-variable data confirmed NOT in cached blocks by test `"does NOT include turn-variable data in any cached block"`. ✅

Closes #32 (acceptance criterion 3)

**References:** https://docs.claude.com/en/docs/build-with-claude/prompt-caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)