### PR TITLE
fix(auth): polish sign-in/sign-up flows (#40)

### DIFF
--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -14,6 +14,7 @@ describe("middleware", () => {
   beforeEach(() => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+    vi.stubEnv("NEXT_PUBLIC_DEV_MODE", "false");
     mockGetUser.mockClear();
   });
 
@@ -30,5 +31,53 @@ describe("middleware", () => {
     const response = await middleware(request);
     expect(response).toBeDefined();
     expect(response.status).toBe(200);
+  });
+
+  describe("AC: unauthenticated users redirected to /auth/login", () => {
+    it("redirects unauthenticated user accessing a protected play route", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+      const { middleware } = await import("@/middleware");
+      const request = new NextRequest("http://localhost:3000/scenarios/abc-123/play");
+      const response = await middleware(request);
+      expect(response.status).toBe(307);
+      const location = response.headers.get("location");
+      expect(location).toMatch(/\/auth\/login/);
+    });
+
+    it("passes redirect param so user returns to intended page after sign-in", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+      const { middleware } = await import("@/middleware");
+      const request = new NextRequest("http://localhost:3000/scenarios/abc-123/play?turn=5");
+      const response = await middleware(request);
+      const location = response.headers.get("location") ?? "";
+      expect(location).toContain("redirect=%2Fscenarios%2Fabc-123%2Fplay");
+    });
+
+    it("allows authenticated user to access protected route without redirect", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: "user-1", email: "test@test.com" } } });
+      const { middleware } = await import("@/middleware");
+      const request = new NextRequest("http://localhost:3000/scenarios/abc-123/play");
+      const response = await middleware(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("allows unauthenticated user to access non-protected route", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+      const { middleware } = await import("@/middleware");
+      const request = new NextRequest("http://localhost:3000/scenarios");
+      const response = await middleware(request);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("AC: dev bypass works when NEXT_PUBLIC_DEV_MODE=true", () => {
+    it("bypasses auth check for protected routes when dev mode is enabled", async () => {
+      vi.stubEnv("NEXT_PUBLIC_DEV_MODE", "true");
+      const { middleware } = await import("@/middleware");
+      const request = new NextRequest("http://localhost:3000/scenarios/abc-123/play");
+      const response = await middleware(request);
+      // Should pass through without redirect (no 307)
+      expect(response.status).not.toBe(307);
+    });
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,7 @@
 import '@testing-library/jest-dom'
 
 // jsdom does not implement scrollIntoView — mock it globally
-window.HTMLElement.prototype.scrollIntoView = function () {}
+// Guard against node environments (e.g. middleware tests with @vitest-environment node)
+if (typeof window !== 'undefined') {
+  window.HTMLElement.prototype.scrollIntoView = function () {}
+}


### PR DESCRIPTION
## Summary

- Fix `tests/setup.ts` to guard `window` access — was crashing the middleware test suite in node environment, leaving zero auth tests running
- Expand `tests/middleware.test.ts` with 5 new acceptance-criteria tests covering all three AC items from issue #40

## Acceptance criteria verified

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Users can sign in via Supabase Auth | MET — `/auth/login` calls `signInWithPassword`, shows errors on failure |
| 2 | Unauthenticated users redirected to `/auth/login` | MET — middleware redirects with `?redirect=` param; tested |
| 3 | Dev bypass works when `NEXT_PUBLIC_DEV_MODE=true` | MET — middleware skips auth check; tested |

## Audit findings (no code changes needed)

- **Two sign-in pages** — already resolved: `/auth/sign-in` and `/auth/sign-up` are server-side redirects to canonical `/auth/login` and `/auth/signup`
- **Post-sign-in redirect** — `?redirect=` param read and sanitized against open-redirect in `sanitizeRedirect()`
- **Error messages** — both forms render errors with `role="alert"` and Stitch-styled error boxes
- **Sign-up flow** — calls `supabase.auth.signUp` with `emailRedirectTo`, shows confirmation state
- **Dev bypass safety** — `NEXT_PUBLIC_*` var baked at build time; enabling in production is an explicit act, no additional guard needed

## Test plan

- [x] `npm test -- --run tests/middleware.test.ts` — 7/7 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing MapboxMap warnings only)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)