### PR TITLE
feat(research): unified pipeline endpoint + caching gap fix

### DIFF
--- a/app/api/scenarios/[id]/research/route.ts
+++ b/app/api/scenarios/[id]/research/route.ts
@@ -1,0 +1,87 @@
+/**
+ * Unified research pipeline endpoint.
+ *
+ * POST /api/scenarios/[id]/research
+ *
+ * Runs all 7 pipeline stages in a single request without requiring user
+ * confirmation between Stage 0 and Stages 1-6.  This is the "scripted"
+ * path used for automated scenario creation (e.g. seeding the Iran
+ * scenario).  Interactive flows should still use the split endpoints:
+ *   POST /research/frame          — Stage 0 + clarifying questions
+ *   POST /research/frame/confirm  — Stage 0 confirmed frame
+ *   POST /research/populate       — Stages 1-6 (async, poll /research/status)
+ *
+ * Request body:
+ *   userDescription  string  — freeform scenario description (required)
+ *   verifiedContext? string  — pre-researched context that skips Stages 1-4
+ *
+ * Response:
+ *   { data: { jobId, status: "started" }, error: null }
+ *
+ * The job runs asynchronously.  Poll GET /research/status?jobId=<id> for
+ * progress.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import {
+  runStage0,
+  createJob,
+  runPopulatePipeline,
+} from "@/lib/ai/research-pipeline";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return Response.json({ data: null, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await request.json().catch(() => ({}));
+  const { userDescription, verifiedContext } = body as {
+    userDescription?: string;
+    verifiedContext?: string;
+  };
+
+  if (!userDescription || typeof userDescription !== "string") {
+    return Response.json(
+      { data: null, error: "userDescription is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Stage 0 — extract scenario frame (no interactive clarification round-trip)
+    const { frame: confirmedFrame } = await runStage0(userDescription);
+
+    // Persist the initial frame so the scenario row is populated even if the
+    // async populate job fails partway through.
+    await supabase
+      .from("scenarios")
+      .update({ scenario_frame: confirmedFrame })
+      .eq("id", id);
+
+    // Create a job and kick off Stages 1-6 without awaiting
+    const jobId = createJob(id);
+    void runPopulatePipeline(
+      jobId,
+      id,
+      userDescription,
+      confirmedFrame,
+      verifiedContext
+    );
+
+    return Response.json({
+      data: { jobId, status: "started" },
+      error: null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Pipeline error";
+    return Response.json({ data: null, error: message }, { status: 500 });
+  }
+}

--- a/lib/ai/research-pipeline.ts
+++ b/lib/ai/research-pipeline.ts
@@ -339,4 +339,44 @@ async function persistPipelineResults(
       sequence_number: i,
     });
   }
+
+  // Store Stage 5 escalation ladders back into the actors table.
+  // The escalation output is { escalationLadders: [...], constraintCascades: [...] }
+  // Store per-actor escalation ladder and the full constraint cascades on the scenario.
+  const escalationObj =
+    results.escalation &&
+    typeof results.escalation === "object" &&
+    !Array.isArray(results.escalation)
+      ? (results.escalation as Record<string, unknown>)
+      : null;
+
+  if (escalationObj) {
+    const ladders = Array.isArray(escalationObj.escalationLadders)
+      ? (escalationObj.escalationLadders as Record<string, unknown>[])
+      : [];
+    for (const ladder of ladders) {
+      const actorId = ladder.actorId as string | undefined;
+      if (!actorId) continue;
+      await supabase
+        .from("actors")
+        .update({ escalation_ladder: ladder })
+        .eq("scenario_id", scenarioId)
+        .eq("actor_id", actorId);
+    }
+
+    // Persist constraint cascades and fog-of-war onto the scenario row
+    // using the existing `phases` column as a staging area until a
+    // dedicated column exists.  We store them under scenario_frame extras
+    // so game logic can retrieve them without a schema migration.
+    await supabase
+      .from("scenarios")
+      .update({
+        scenario_frame: {
+          ...confirmedFrame,
+          _constraintCascades: escalationObj.constraintCascades ?? [],
+          _fogOfWar: results.fogOfWar ?? [],
+        },
+      })
+      .eq("id", scenarioId);
+  }
 }

--- a/tests/api/research-pipeline-unified.test.ts
+++ b/tests/api/research-pipeline-unified.test.ts
@@ -1,0 +1,314 @@
+// @vitest-environment node
+/**
+ * Tests for the unified POST /api/scenarios/[id]/research endpoint.
+ *
+ * This endpoint runs all 7 research pipeline stages in one request:
+ *   Stage 0 (frame) → Stages 1-6 (populate, async)
+ *
+ * Acceptance criteria (issue #31):
+ *   - POST /api/scenarios/[id]/research triggers all 7 stages
+ *   - Each stage output stored in Supabase
+ *   - Prompt caching applied to stable stage prompts
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock @anthropic-ai/sdk — must be before any imports that use it.
+// NOTE: vi.mock factories are hoisted — do NOT reference external variables.
+// ---------------------------------------------------------------------------
+const mockCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Supabase server mock — inline factory only (no external variable refs)
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "test-user" } } }),
+    },
+    from: vi.fn().mockReturnValue({
+      update: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({}) }),
+      upsert: vi.fn().mockReturnValue({}),
+    }),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Supabase service mock — inline factory only
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      update: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({}) }),
+      upsert: vi.fn().mockReturnValue({}),
+    }),
+  }),
+}));
+
+import { POST } from "@/app/api/scenarios/[id]/research/route";
+import * as pipelineModule from "@/lib/ai/research-pipeline";
+import { createServiceClient } from "@/lib/supabase/service";
+import type { ScenarioFrame } from "@/lib/types/simulation";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const mockFrame: ScenarioFrame = {
+  conflictName: "Iran-US Conflict",
+  coreQuestion: "Can the US achieve strategic objectives without ground invasion?",
+  timeframeStart: "2023-01-01",
+  timeframeCurrent: "2026-04-18",
+  geographicScope: "Middle East",
+  userAnalysis: "Comprehensive Iran-US scenario",
+  suggestedActors: [],
+  relevanceCriteria: "directly involved in conflict",
+  keyDynamics: ["nuclear escalation", "proxy warfare"],
+  actorFramings: [],
+};
+
+function makeTextResponse(json: unknown) {
+  // Wrap in json code fence so callClaude's first regex match handles both
+  // arrays and objects correctly (bare array regex \{...\} can misparse arrays).
+  return {
+    content: [{ type: "text", text: `\`\`\`json\n${JSON.stringify(json)}\n\`\`\`` }],
+    usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 80 },
+  };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/scenarios/test-id/research", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Auth + validation
+// ---------------------------------------------------------------------------
+describe("POST /api/scenarios/[id]/research — validation", () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it("returns 400 if userDescription is missing", async () => {
+    // Stub runStage0 so this test doesn't hit the SDK
+    const spy = vi
+      .spyOn(pipelineModule, "runStage0")
+      .mockResolvedValue({ frame: mockFrame, clarifyingQuestions: [] });
+
+    const req = makeRequest({});
+    const res = await POST(req, { params: Promise.resolve({ id: "test-id" }) });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("userDescription");
+
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path: Stage 0 → Stages 1-6
+// ---------------------------------------------------------------------------
+describe("POST /api/scenarios/[id]/research — full pipeline", () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it("calls runStage0 then runPopulatePipeline with the confirmed frame", async () => {
+    const stage0Spy = vi
+      .spyOn(pipelineModule, "runStage0")
+      .mockResolvedValue({ frame: mockFrame, clarifyingQuestions: ["Q1?"] });
+
+    const populateSpy = vi
+      .spyOn(pipelineModule, "runPopulatePipeline")
+      .mockResolvedValue(undefined);
+
+    const req = makeRequest({ userDescription: "Iran-US conflict scenario" });
+    const res = await POST(req, { params: Promise.resolve({ id: "test-id" }) });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.error).toBeNull();
+    expect(json.data.status).toBe("started");
+    expect(typeof json.data.jobId).toBe("string");
+
+    expect(stage0Spy).toHaveBeenCalledWith("Iran-US conflict scenario");
+    expect(populateSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      "test-id",
+      "Iran-US conflict scenario",
+      mockFrame,
+      undefined
+    );
+
+    stage0Spy.mockRestore();
+    populateSpy.mockRestore();
+  });
+
+  it("passes verifiedContext to runPopulatePipeline when provided", async () => {
+    const stage0Spy = vi
+      .spyOn(pipelineModule, "runStage0")
+      .mockResolvedValue({ frame: mockFrame, clarifyingQuestions: [] });
+
+    const populateSpy = vi
+      .spyOn(pipelineModule, "runPopulatePipeline")
+      .mockResolvedValue(undefined);
+
+    const req = makeRequest({
+      userDescription: "Iran-US conflict",
+      verifiedContext: "pre-researched-context-data",
+    });
+    await POST(req, { params: Promise.resolve({ id: "test-id" }) });
+
+    expect(populateSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      "test-id",
+      "Iran-US conflict",
+      mockFrame,
+      "pre-researched-context-data"
+    );
+
+    stage0Spy.mockRestore();
+    populateSpy.mockRestore();
+  });
+
+  it("returns 500 if Stage 0 throws", async () => {
+    const stage0Spy = vi
+      .spyOn(pipelineModule, "runStage0")
+      .mockRejectedValue(new Error("Claude API error"));
+
+    const req = makeRequest({ userDescription: "Iran-US conflict" });
+    const res = await POST(req, { params: Promise.resolve({ id: "test-id" }) });
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toContain("Claude API error");
+
+    stage0Spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt caching — every callClaude call should have cache_control on system
+// ---------------------------------------------------------------------------
+describe("Prompt caching in research pipeline", () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it("attaches cache_control: ephemeral to system prompt in every stage call", async () => {
+    // Stage 0
+    mockCreate.mockResolvedValueOnce(
+      makeTextResponse({ frame: mockFrame, clarifyingQuestions: [] })
+    );
+    // Stages 1-6
+    for (let i = 0; i < 6; i++) {
+      mockCreate.mockResolvedValueOnce(
+        makeTextResponse(
+          i < 2
+            ? [{ id: "us", name: "United States" }]
+            : i === 4
+            ? { escalationLadders: [], constraintCascades: [] }
+            : []
+        )
+      );
+    }
+
+    const jobId = pipelineModule.createJob("scenario-cache-test");
+    await pipelineModule.runStage0("test description");
+    await pipelineModule.runPopulatePipeline(
+      jobId,
+      "scenario-cache-test",
+      "test description",
+      mockFrame
+    );
+
+    // All 7 calls (Stage 0 + Stages 1-6) must use cache_control
+    expect(mockCreate.mock.calls.length).toBe(7);
+    for (const call of mockCreate.mock.calls) {
+      const systemBlocks = call[0].system;
+      expect(Array.isArray(systemBlocks)).toBe(true);
+      expect(systemBlocks[0]).toMatchObject({
+        type: "text",
+        cache_control: { type: "ephemeral" },
+      });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stage 5 escalation ladder storage in actors table
+// ---------------------------------------------------------------------------
+describe("runPopulatePipeline — Stage 5 escalation ladder persisted to actors", () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it("updates actors table with escalation_ladder after Stage 5 completes", async () => {
+    // Build a controllable Supabase mock.
+    // .update().eq().eq() — chain returns itself at each .eq() step.
+    const eqChain: Record<string, unknown> = {};
+    const eqFn = vi.fn().mockReturnValue(eqChain);
+    eqChain.eq = eqFn;
+    const updateMock = vi.fn().mockReturnValue(eqChain);
+    const upsertMock = vi.fn().mockReturnValue({});
+    const fromMock = vi.fn().mockReturnValue({
+      update: updateMock,
+      upsert: upsertMock,
+    });
+
+    vi.mocked(createServiceClient).mockReturnValue(
+      // Cast through unknown to satisfy the full SupabaseClient type — this
+      // is a test double that only implements the methods under test.
+      { from: fromMock } as unknown as ReturnType<typeof createServiceClient>
+    );
+
+    // Stage 1: 2 actors
+    mockCreate.mockResolvedValueOnce(
+      makeTextResponse([
+        { id: "us", name: "United States", type: "nation_state", description: "desc" },
+        { id: "iran", name: "Iran", type: "nation_state", description: "desc" },
+      ])
+    );
+    // Stage 2: states
+    mockCreate.mockResolvedValueOnce(
+      makeTextResponse([{ actorId: "us" }, { actorId: "iran" }])
+    );
+    // Stage 3: relationships
+    mockCreate.mockResolvedValueOnce(
+      makeTextResponse([{ actorA: "us", actorB: "iran", type: "adversary" }])
+    );
+    // Stage 4: events
+    mockCreate.mockResolvedValueOnce(makeTextResponse([{ id: "evt1" }]));
+    // Stage 5: escalation ladders for 2 actors
+    mockCreate.mockResolvedValueOnce(
+      makeTextResponse({
+        escalationLadders: [
+          { actorId: "us", escalation: { currentRung: 3, rungs: [] } },
+          { actorId: "iran", escalation: { currentRung: 4, rungs: [] } },
+        ],
+        constraintCascades: [{ id: "cascade1" }],
+      })
+    );
+    // Stage 6: fog of war
+    mockCreate.mockResolvedValueOnce(makeTextResponse([]));
+
+    const jobId = pipelineModule.createJob("scenario-escalation-persist");
+    await pipelineModule.runPopulatePipeline(
+      jobId,
+      "scenario-escalation-persist",
+      "test description",
+      mockFrame
+    );
+
+    const job = pipelineModule.getJob(jobId);
+    if (job?.status !== "complete") {
+      console.error("Job failed with error:", job?.error);
+    }
+    expect(job?.status).toBe("complete");
+
+    // Verify escalation_ladder updates were made (one per actor = 2)
+    const escalationUpdates = updateMock.mock.calls.filter((args: unknown[]) => {
+      const obj = args[0];
+      return typeof obj === "object" && obj !== null && "escalation_ladder" in obj;
+    });
+    expect(escalationUpdates.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/api/research-pipeline.test.ts
+++ b/tests/api/research-pipeline.test.ts
@@ -22,6 +22,20 @@ vi.mock("@/lib/supabase/server", () => ({
   }),
 }));
 
+// ---------------------------------------------------------------------------
+// Mock @/lib/supabase/service — used by persistPipelineResults in the pipeline
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({}) }),
+      }),
+      upsert: vi.fn().mockReturnValue({}),
+    }),
+  }),
+}));
+
 import { callClaude } from "@/lib/ai/anthropic";
 import * as pipelineModule from "@/lib/ai/research-pipeline";
 import {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,7 @@
 import '@testing-library/jest-dom'
 
-// jsdom does not implement scrollIntoView — mock it globally
-window.HTMLElement.prototype.scrollIntoView = function () {}
+// jsdom does not implement scrollIntoView — mock it globally.
+// Guard against node environment where window is not defined.
+if (typeof window !== 'undefined') {
+  window.HTMLElement.prototype.scrollIntoView = function () {}
+}


### PR DESCRIPTION
## Summary

- Add `POST /api/scenarios/[id]/research` — single-shot endpoint that runs all 7 pipeline stages without interactive confirmation (closes #31)
- Fix Stage 5/6 persistence gap: escalation ladders written to `actors.escalation_ladder` per actor; constraint cascades + fog-of-war stored on scenario row
- Fix test infrastructure: guard `window` reference in `tests/setup.ts` so node-environment tests don't throw; add missing `@/lib/supabase/service` mock to existing pipeline tests

## Why separate from the interactive flow?

The existing split endpoints (`/research/frame` → `/research/frame/confirm` → `/research/populate`) remain the frontend path. The new `/research` endpoint exists for scripted use (CI seeding, the Iran scenario `verifiedContext` flow) where user confirmation is not required.

## Caching state

Prompt caching is **already present** on all 7 stages. `callClaude()` in `lib/ai/anthropic.ts` wraps every system prompt with `cache_control: { type: "ephemeral" }`. No PR #70 dependency needed.

## Test plan

- [x] `npm test -- --run tests/api/research-pipeline-unified.test.ts` → 6/6 pass
- [x] `npm test -- --run tests/api/research-pipeline.test.ts` → 21/21 pass
- [x] `npm run typecheck` → clean
- [x] `npm run lint` → clean (pre-existing MapboxMap warnings only)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)