### PR TITLE
feat(#58): DB migration + cost-tracker module (PR 1 of 5)

### DIFF
--- a/lib/ai/cost-tracker.ts
+++ b/lib/ai/cost-tracker.ts
@@ -1,0 +1,268 @@
+/**
+ * cost-tracker.ts
+ *
+ * Per-user daily token budget tracking for issue #58 rate limiting.
+ * All writes use the service-role client to bypass RLS.
+ * Skips all work in NEXT_PUBLIC_DEV_MODE=true.
+ */
+
+import { createServiceClient } from '@/lib/supabase/service'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface BudgetStatus {
+  allowed: boolean
+  reason?: 'tokens_exceeded' | 'turns_exceeded' | 'concurrent_turn' | 'auth_required'
+  tokensUsed: number
+  tokensLimit: number
+  turnsCompleted: number
+  turnsLimit: number
+  lastTurnStartedAt: string | null
+}
+
+export interface Usage {
+  input_tokens: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+  output_tokens: number
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** UTC date string for today, e.g. "2026-04-20" */
+function today(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** True when running in dev-mode bypass — no budget checks or DB writes. */
+function isDevMode(): boolean {
+  return process.env.NEXT_PUBLIC_DEV_MODE === 'true'
+}
+
+/** Unlimited (bypass) sentinel value */
+const UNLIMITED = -1
+
+/** Concurrent-turn window in milliseconds */
+const CONCURRENT_WINDOW_MS = 60_000
+
+/** Default row values used when creating a budget row for the first time */
+const DEFAULT_TOKENS_LIMIT = 2_000_000
+const DEFAULT_TURNS_LIMIT = 50
+
+/** Shape of a row from user_token_budgets */
+interface BudgetRow {
+  user_id: string
+  day: string
+  tokens_used: number
+  tokens_limit: number
+  turns_completed: number
+  turns_limit: number
+  last_turn_started_at: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a user is allowed to start a new turn.
+ * Creates a default budget row on first call for the day.
+ *
+ * Returns allowed=true in dev mode or when the relevant limit is -1.
+ */
+export async function checkBudget(userId: string): Promise<BudgetStatus> {
+  if (isDevMode()) {
+    return devModeStatus()
+  }
+
+  const supabase = createServiceClient()
+  const day = today()
+
+  // Upsert a default row if none exists (first call of the day).
+  const { error: upsertError } = await supabase
+    .from('user_token_budgets')
+    .upsert(
+      {
+        user_id: userId,
+        day,
+        tokens_used: 0,
+        tokens_limit: DEFAULT_TOKENS_LIMIT,
+        turns_completed: 0,
+        turns_limit: DEFAULT_TURNS_LIMIT,
+        last_turn_started_at: null,
+      },
+      { onConflict: 'user_id,day', ignoreDuplicates: true }
+    )
+
+  if (upsertError) {
+    throw new Error(`cost-tracker upsert failed: ${upsertError.message}`)
+  }
+
+  // Read back the current row.
+  const { data, error: selectError } = await supabase
+    .from('user_token_budgets')
+    .select(
+      'user_id,day,tokens_used,tokens_limit,turns_completed,turns_limit,last_turn_started_at'
+    )
+    .eq('user_id', userId)
+    .eq('day', day)
+    .single<BudgetRow>()
+
+  if (selectError || !data) {
+    throw new Error(`cost-tracker read failed: ${selectError?.message ?? 'no row'}`)
+  }
+
+  return evaluate(data)
+}
+
+/**
+ * Increment tokens_used for the user's current-day budget.
+ * Totals all token fields from the usage object.
+ * No-op in dev mode.
+ */
+export async function recordTokens(userId: string, usage: Usage): Promise<void> {
+  if (isDevMode()) return
+
+  const delta =
+    usage.input_tokens +
+    (usage.cache_creation_input_tokens ?? 0) +
+    (usage.cache_read_input_tokens ?? 0) +
+    usage.output_tokens
+
+  const supabase = createServiceClient()
+  const day = today()
+
+  const { error } = await supabase.rpc('increment_tokens_used', {
+    p_user_id: userId,
+    p_day: day,
+    p_delta: delta,
+  })
+
+  if (error) {
+    // Fallback: use a read-modify-write if the RPC doesn't exist yet.
+    // This is safe for low-concurrency scenarios; high-concurrency is handled
+    // by the Postgres RPC with row-level locking (PR 2).
+    const { data: row } = await supabase
+      .from('user_token_budgets')
+      .select('tokens_used')
+      .eq('user_id', userId)
+      .eq('day', day)
+      .single<Pick<BudgetRow, 'tokens_used'>>()
+
+    const current = row?.tokens_used ?? 0
+    await supabase
+      .from('user_token_budgets')
+      .update({ tokens_used: current + delta })
+      .eq('user_id', userId)
+      .eq('day', day)
+  }
+}
+
+/**
+ * Atomically increment turns_completed by 1 for the user's current-day budget.
+ * No-op in dev mode.
+ */
+export async function incrementTurn(userId: string): Promise<void> {
+  if (isDevMode()) return
+
+  const supabase = createServiceClient()
+  const day = today()
+
+  const { error } = await supabase.rpc('increment_turns_completed', {
+    p_user_id: userId,
+    p_day: day,
+  })
+
+  if (error) {
+    // Fallback: read-modify-write (low-concurrency safe).
+    const { data: row } = await supabase
+      .from('user_token_budgets')
+      .select('turns_completed')
+      .eq('user_id', userId)
+      .eq('day', day)
+      .single<Pick<BudgetRow, 'turns_completed'>>()
+
+    const current = row?.turns_completed ?? 0
+    await supabase
+      .from('user_token_budgets')
+      .update({ turns_completed: current + 1 })
+      .eq('user_id', userId)
+      .eq('day', day)
+  }
+}
+
+/**
+ * Set last_turn_started_at to now for the user's current-day budget.
+ * Used to detect concurrent turn submissions.
+ * No-op in dev mode.
+ */
+export async function markTurnStarted(userId: string): Promise<void> {
+  if (isDevMode()) return
+
+  const supabase = createServiceClient()
+  const day = today()
+
+  const { error } = await supabase
+    .from('user_token_budgets')
+    .update({ last_turn_started_at: new Date().toISOString() })
+    .eq('user_id', userId)
+    .eq('day', day)
+
+  if (error) {
+    throw new Error(`cost-tracker markTurnStarted failed: ${error.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function evaluate(row: BudgetRow): BudgetStatus {
+  const base: Omit<BudgetStatus, 'allowed' | 'reason'> = {
+    tokensUsed: row.tokens_used,
+    tokensLimit: row.tokens_limit,
+    turnsCompleted: row.turns_completed,
+    turnsLimit: row.turns_limit,
+    lastTurnStartedAt: row.last_turn_started_at,
+  }
+
+  // Admin bypass: limit of -1 means unlimited.
+  if (row.tokens_limit === UNLIMITED && row.turns_limit === UNLIMITED) {
+    return { allowed: true, ...base }
+  }
+
+  // Tokens check (skip if unlimited).
+  if (row.tokens_limit !== UNLIMITED && row.tokens_used >= row.tokens_limit) {
+    return { allowed: false, reason: 'tokens_exceeded', ...base }
+  }
+
+  // Turns check (skip if unlimited).
+  if (row.turns_limit !== UNLIMITED && row.turns_completed >= row.turns_limit) {
+    return { allowed: false, reason: 'turns_exceeded', ...base }
+  }
+
+  // Concurrent-turn check: last_turn_started_at within 60 s.
+  if (row.last_turn_started_at !== null) {
+    const elapsed = Date.now() - new Date(row.last_turn_started_at).getTime()
+    if (elapsed < CONCURRENT_WINDOW_MS) {
+      return { allowed: false, reason: 'concurrent_turn', ...base }
+    }
+  }
+
+  return { allowed: true, ...base }
+}
+
+function devModeStatus(): BudgetStatus {
+  return {
+    allowed: true,
+    tokensUsed: 0,
+    tokensLimit: UNLIMITED,
+    turnsCompleted: 0,
+    turnsLimit: UNLIMITED,
+    lastTurnStartedAt: null,
+  }
+}

--- a/supabase/migrations/20260420000000_user_token_budgets.sql
+++ b/supabase/migrations/20260420000000_user_token_budgets.sql
@@ -1,0 +1,31 @@
+-- Per-user daily token budget tracking.
+-- Supports issue #58 rate limiting. One row per user per UTC day.
+
+CREATE TABLE IF NOT EXISTS user_token_budgets (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  day DATE NOT NULL,
+  tokens_used BIGINT NOT NULL DEFAULT 0,
+  tokens_limit BIGINT NOT NULL DEFAULT 2000000,
+  turns_completed INT NOT NULL DEFAULT 0,
+  turns_limit INT NOT NULL DEFAULT 50,
+  last_turn_started_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_token_budgets_day ON user_token_budgets(day);
+
+-- Reuse the shared update_updated_at() function defined in the initial schema migration.
+DROP TRIGGER IF EXISTS trg_user_token_budgets_updated_at ON user_token_budgets;
+CREATE TRIGGER trg_user_token_budgets_updated_at
+BEFORE UPDATE ON user_token_budgets
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- RLS: users can read their own row
+ALTER TABLE user_token_budgets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_token_budgets_select_own ON user_token_budgets
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- No INSERT/UPDATE policy — writes go through service role only.

--- a/tests/ai/cost-tracker.test.ts
+++ b/tests/ai/cost-tracker.test.ts
@@ -1,0 +1,294 @@
+// tests/ai/cost-tracker.test.ts
+// Tests for lib/ai/cost-tracker — Supabase service client is fully mocked.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock setup (must come before module imports)
+// ---------------------------------------------------------------------------
+
+// Shared mock state so individual tests can inject per-row data.
+let mockRowData: Record<string, unknown> | null = null
+let mockUpsertError: { message: string } | null = null
+let mockSelectError: { message: string } | null = null
+let mockUpdateError: { message: string } | null = null
+let mockRpcError: { message: string } | null = null
+
+const mockUpdate = vi.fn()
+const mockRpc = vi.fn()
+
+// Chain builder for .from().select().eq().eq().single()
+function buildSelectChain(data: Record<string, unknown> | null, error: { message: string } | null) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data, error }),
+  }
+  return chain
+}
+
+// The mock client factory — each test call to createServiceClient returns this.
+function createMockClient() {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'user_token_budgets') {
+        return {
+          upsert: vi.fn().mockResolvedValue({ error: mockUpsertError }),
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: mockRowData, error: mockSelectError }),
+              }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: mockUpdateError }),
+            }),
+          }),
+        }
+      }
+      return {}
+    }),
+    rpc: mockRpc.mockResolvedValue({ error: mockRpcError }),
+  }
+}
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(() => createMockClient()),
+}))
+
+// Import module AFTER mock is declared.
+import {
+  checkBudget,
+  recordTokens,
+  incrementTurn,
+  markTurnStarted,
+} from '@/lib/ai/cost-tracker'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRow(overrides: Partial<{
+  tokens_used: number
+  tokens_limit: number
+  turns_completed: number
+  turns_limit: number
+  last_turn_started_at: string | null
+}> = {}): Record<string, unknown> {
+  return {
+    user_id: 'user-1',
+    day: '2026-04-20',
+    tokens_used: 0,
+    tokens_limit: 2_000_000,
+    turns_completed: 0,
+    turns_limit: 50,
+    last_turn_started_at: null,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('checkBudget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpsertError = null
+    mockSelectError = null
+    mockUpdateError = null
+    mockRpcError = null
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  it('creates a default row on first call (upsert is called)', async () => {
+    mockRowData = makeRow()
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    const mockClient = createMockClient()
+    vi.mocked(createServiceClient).mockReturnValue(mockClient as unknown as ReturnType<typeof createServiceClient>)
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(true)
+    expect(mockClient.from).toHaveBeenCalledWith('user_token_budgets')
+  })
+
+  it('returns allowed=true when under both limits', async () => {
+    mockRowData = makeRow({ tokens_used: 100_000, turns_completed: 5 })
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(true)
+    expect(status.tokensUsed).toBe(100_000)
+    expect(status.turnsCompleted).toBe(5)
+    expect(status.reason).toBeUndefined()
+  })
+
+  it('returns tokens_exceeded when tokens_used >= tokens_limit', async () => {
+    mockRowData = makeRow({ tokens_used: 2_000_000, tokens_limit: 2_000_000 })
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(false)
+    expect(status.reason).toBe('tokens_exceeded')
+  })
+
+  it('returns turns_exceeded when turns_completed >= turns_limit', async () => {
+    mockRowData = makeRow({ turns_completed: 50, turns_limit: 50 })
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(false)
+    expect(status.reason).toBe('turns_exceeded')
+  })
+
+  it('returns concurrent_turn when last_turn_started_at is within 60 seconds', async () => {
+    const recent = new Date(Date.now() - 20_000).toISOString() // 20 s ago
+    mockRowData = makeRow({ last_turn_started_at: recent })
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(false)
+    expect(status.reason).toBe('concurrent_turn')
+  })
+
+  it('returns allowed=true when last_turn_started_at is older than 60 seconds', async () => {
+    const old = new Date(Date.now() - 90_000).toISOString() // 90 s ago
+    mockRowData = makeRow({ last_turn_started_at: old })
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(true)
+  })
+
+  it('returns allowed=true when tokens_limit is -1 (admin bypass)', async () => {
+    mockRowData = makeRow({ tokens_used: 99_999_999, tokens_limit: -1, turns_limit: -1 })
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(true)
+    expect(status.reason).toBeUndefined()
+  })
+
+  it('returns allowed=true in dev mode without hitting Supabase', async () => {
+    process.env.NEXT_PUBLIC_DEV_MODE = 'true'
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    vi.mocked(createServiceClient).mockClear()
+
+    const status = await checkBudget('user-1')
+
+    expect(status.allowed).toBe(true)
+    expect(status.tokensLimit).toBe(-1)
+    expect(status.turnsLimit).toBe(-1)
+    expect(vi.mocked(createServiceClient)).not.toHaveBeenCalled()
+  })
+})
+
+describe('recordTokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRpcError = null
+    mockSelectError = null
+    mockUpdateError = null
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  it('sums all token fields including cache tokens', async () => {
+    // rpc succeeds — capture args
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    const mockClient = createMockClient()
+    // Make rpc succeed so we can inspect the call.
+    mockClient.rpc = vi.fn().mockResolvedValue({ error: null })
+    vi.mocked(createServiceClient).mockReturnValue(mockClient as unknown as ReturnType<typeof createServiceClient>)
+
+    await recordTokens('user-1', {
+      input_tokens: 1000,
+      cache_creation_input_tokens: 200,
+      cache_read_input_tokens: 50,
+      output_tokens: 500,
+    })
+
+    expect(mockClient.rpc).toHaveBeenCalledWith('increment_tokens_used', {
+      p_user_id: 'user-1',
+      p_day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      p_delta: 1750, // 1000 + 200 + 50 + 500
+    })
+  })
+
+  it('is a no-op in dev mode', async () => {
+    process.env.NEXT_PUBLIC_DEV_MODE = 'true'
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    vi.mocked(createServiceClient).mockClear()
+
+    await recordTokens('user-1', { input_tokens: 100, output_tokens: 50 })
+
+    expect(vi.mocked(createServiceClient)).not.toHaveBeenCalled()
+  })
+})
+
+describe('incrementTurn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRpcError = null
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  it('calls the increment_turns_completed RPC with correct args', async () => {
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    const mockClient = createMockClient()
+    mockClient.rpc = vi.fn().mockResolvedValue({ error: null })
+    vi.mocked(createServiceClient).mockReturnValue(mockClient as unknown as ReturnType<typeof createServiceClient>)
+
+    await incrementTurn('user-1')
+
+    expect(mockClient.rpc).toHaveBeenCalledWith('increment_turns_completed', {
+      p_user_id: 'user-1',
+      p_day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    })
+  })
+
+  it('is a no-op in dev mode', async () => {
+    process.env.NEXT_PUBLIC_DEV_MODE = 'true'
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    vi.mocked(createServiceClient).mockClear()
+
+    await incrementTurn('user-1')
+
+    expect(vi.mocked(createServiceClient)).not.toHaveBeenCalled()
+  })
+})
+
+describe('markTurnStarted', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateError = null
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_DEV_MODE
+  })
+
+  it('is a no-op in dev mode', async () => {
+    process.env.NEXT_PUBLIC_DEV_MODE = 'true'
+    const { createServiceClient } = await import('@/lib/supabase/service')
+    vi.mocked(createServiceClient).mockClear()
+
+    await markTurnStarted('user-1')
+
+    expect(vi.mocked(createServiceClient)).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Part of #58. See design spec in PR #79. This PR is mechanical infrastructure only — no route integration (comes in PR 2).

## Summary

- `supabase/migrations/20260420000000_user_token_budgets.sql` — new table with composite PK `(user_id, day)`, select-own RLS policy, reuses the existing `update_updated_at()` trigger function
- `lib/ai/cost-tracker.ts` — standalone module: `checkBudget`, `recordTokens`, `incrementTurn`, `markTurnStarted`; dev-mode bypass (`NEXT_PUBLIC_DEV_MODE=true`); limit `-1` = admin unlimited override
- `tests/ai/cost-tracker.test.ts` — 13 tests covering all budget decision paths, token summation, concurrent-turn detection, dev-mode no-op

## Test plan

- [x] `npm test -- --run tests/ai/cost-tracker.test.ts` → 13/13 pass
- [x] `npm run typecheck` → clean
- [x] `npm run lint` → clean (pre-existing MapboxMap warnings only)
- [ ] Migration to be applied to Supabase — no automated apply in CI yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)