### PR TITLE
fix: inject service client into state-engine for background pipeline

### DIFF
--- a/app/api/scenarios/[id]/branches/[branchId]/advance/route.ts
+++ b/app/api/scenarios/[id]/branches/[branchId]/advance/route.ts
@@ -81,7 +81,7 @@ async function runFullPipeline(
 
     // ── Load branch state + divergence ───────────────────────────────────
     const [branchState, branchDivergence] = await Promise.all([
-      getStateAtTurn(branchId, headCommitId),
+      getStateAtTurn(branchId, headCommitId, undefined, { client: supabase }),
       computeBranchDivergence(supabase, branchId),
     ])
 
@@ -216,7 +216,7 @@ async function runFullPipeline(
 
     // ── Persist state ────────────────────────────────────────────────────
     const newState = applyEventEffects(branchState, resolution.effects)
-    await persistStateSnapshot(scenarioId, branchId, commitId, newState)
+    await persistStateSnapshot(scenarioId, branchId, commitId, newState, { client: supabase })
 
     // ── Update turn_commit with full results ─────────────────────────────
     await supabase.from('turn_commits').update({

--- a/lib/game/state-engine.ts
+++ b/lib/game/state-engine.ts
@@ -7,6 +7,26 @@ import type {
   LiveGlobalState,
 } from '@/lib/types/simulation'
 import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+/**
+ * Minimal interface for the Supabase client methods used here.
+ * Accepts both the cookie-based server client (from lib/supabase/server)
+ * and the service-role client (from lib/supabase/service) — both expose the
+ * same query-builder shape for the reads/writes these functions perform.
+ *
+ * Callers without an HTTP request context (e.g. background pipelines) MUST
+ * pass a service client via `{ client }` to avoid the cookie() lookup throwing.
+ */
+type StateEngineClient = Awaited<ReturnType<typeof createClient>> | ReturnType<typeof createServiceClient>
+
+/**
+ * Resolve the Supabase client to use. If one is injected, use it. Otherwise
+ * fall back to the cookie-based client (works in HTTP request handlers only).
+ */
+async function resolveClient(injected?: StateEngineClient): Promise<StateEngineClient> {
+  return injected ?? (await createClient())
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -171,9 +191,10 @@ export function applyEventEffects(
 export async function getStateAtTurn(
   branchId: string,
   turnCommitId: string,
-  asOfDate?: string
+  asOfDate?: string,
+  options?: { client?: StateEngineClient }
 ): Promise<BranchStateAtTurn> {
-  const supabase = await createClient()
+  const supabase = await resolveClient(options?.client)
 
   const { data: snapshots, error: snapshotsError } = await supabase
     .from('actor_state_snapshots')
@@ -284,9 +305,10 @@ export async function persistStateSnapshot(
   scenarioId: string,
   branchId: string,
   turnCommitId: string,
-  state: BranchStateAtTurn
+  state: BranchStateAtTurn,
+  options?: { client?: StateEngineClient }
 ): Promise<void> {
-  const supabase = await createClient()
+  const supabase = await resolveClient(options?.client)
 
   const rows = Object.entries(state.actor_states).map(([actorId, actorState]) => ({
     scenario_id:            scenarioId,
@@ -315,10 +337,11 @@ export async function persistStateSnapshot(
 export async function forkStateForBranch(
   parentBranchId: string,
   forkTurnCommitId: string,
-  newBranchId: string
+  newBranchId: string,
+  options?: { client?: StateEngineClient }
 ): Promise<BranchStateAtTurn> {
-  const supabase = await createClient()
-  const parentState = await getStateAtTurn(parentBranchId, forkTurnCommitId)
+  const supabase = await resolveClient(options?.client)
+  const parentState = await getStateAtTurn(parentBranchId, forkTurnCommitId, undefined, options)
 
   // Deep copy — mutations to fork must not affect parent
   const forkedState: BranchStateAtTurn = JSON.parse(JSON.stringify(parentState))


### PR DESCRIPTION
## Problem

`getStateAtTurn` and `persistStateSnapshot` in `lib/game/state-engine.ts` call `createClient()` from `lib/supabase/server.ts`, which uses Next.js's `cookies()` API to build a cookie-authenticated Supabase client. That works in HTTP request handlers but **throws outside a request context**.

PR #65 (`/advance` route) runs the AI pipeline via `waitUntil` from `@vercel/functions` **after** the response is sent. At that point there's no active request context, so `getStateAtTurn` throws on the very first call and the outer try/catch catches it, marking the turn `failed` and broadcasting `turn_failed` to the client. **Every real turn submission fails.**

This was flagged as a known follow-up in PR #65's description, but it blocks end-to-end AI turn submission so it's being addressed now.

## Fix

Add an optional `{ client? }` param to the three state-engine functions that hit the DB:
- `getStateAtTurn`
- `persistStateSnapshot`
- `forkStateForBranch`

When injected, use that client. Otherwise fall back to the cookie client (HTTP-route callers unchanged).

`/advance` now passes its existing `createServiceClient()` through to both `getStateAtTurn` and `persistStateSnapshot`.

Other callers (`actor-panel`, `map-assets`, `resolution`, `actor` routes, `game-loop.ts`) all run in HTTP request context and remain on the default cookie path.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test -- --run tests/api/advance.test.ts tests/game/turn-helpers.test.ts` — 270/270 pass
- First real pipeline run should now complete (was previously failing at `getStateAtTurn`)

## Risk
Low. Additive param. Default behavior unchanged for all non-advance callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)