### PR TITLE
chore: exclude .claude/worktrees + dist + .next from vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
-    exclude: ['node_modules', '.worktrees/**'],
+    exclude: ['node_modules', '.worktrees/**', '.claude/worktrees/**', '**/dist/**', '**/.next/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Tiny config-only PR. Stops vitest from scanning subagent worktrees (which were duplicating every test file) and common build output directories.

**Before:** 340+ tests discovered including worktree copies; 11 'failed' test files that were duplicates of tests/api/research-pipeline.test.ts.
**After:** clean 244 tests from real sources only.

No runtime impact. Safe to merge any time.