### PR TITLE
fix(branches): set created_by + bootstrap profile row on fork

### DIFF
--- a/app/api/branches/route.ts
+++ b/app/api/branches/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
 import { resolveScenarioId } from '@/lib/supabase/resolve-scenario'
 import { DEV_TRUNK_BRANCH, DEV_ACTORS } from '@/lib/game/dev-branches'
 
@@ -89,6 +90,31 @@ export async function POST(request: Request) {
     }
 
     const supabase = await createClient()
+
+    // Auth required — the `branches` table has `created_by NOT NULL` and an
+    // RLS insert policy that checks `created_by = auth.uid()`. Without this
+    // we'd hit either a NOT NULL violation or a silent RLS denial.
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'Authentication required to create a branch' },
+        { status: 401 },
+      )
+    }
+
+    // Defensive profile bootstrap — the schema has FK `branches.created_by -> profiles(id)`
+    // but there is no trigger to auto-create a profile row when a user signs up via
+    // Supabase Auth. Use the service role to upsert (profiles has no INSERT policy, so
+    // the cookie client would be blocked by RLS).
+    const usernameCandidate = user.email?.split('@')[0] ?? `user_${user.id.slice(0, 8)}`
+    const serviceClient = createServiceClient()
+    await serviceClient
+      .from('profiles')
+      .upsert(
+        { id: user.id, username: usernameCandidate },
+        { onConflict: 'id', ignoreDuplicates: true },
+      )
+
     const scenarioId = await resolveScenarioId(supabase, rawScenarioId)
 
     // Find the trunk branch to use as parent if not supplied
@@ -124,6 +150,7 @@ export async function POST(request: Request) {
       is_trunk:         false,
       status:           'active',
       parent_branch_id: resolvedParentId,
+      created_by:       user.id,
     }
     if (headCommitId) {
       insertData.head_commit_id       = headCommitId


### PR DESCRIPTION
## Summary

Fork was failing because:
1. POST `/api/branches` didn't set `created_by` — but the schema has it as `NOT NULL` with an RLS policy requiring `created_by = auth.uid()`.
2. No trigger creates a `profiles` row when a user signs up via Supabase Auth — so even with fix 1, the FK `branches.created_by -> profiles(id)` would fail.

## Fix

- Authenticate the request; return 401 if no user
- Upsert the profile row via **service client** (profiles has no INSERT RLS policy, cookie client would be blocked)
- Insert branch with `created_by: user.id`

## Next step (not in this PR)

Add a Postgres trigger:
```sql
CREATE OR REPLACE FUNCTION handle_new_user()
RETURNS TRIGGER AS $$
BEGIN
  INSERT INTO public.profiles (id, username)
  VALUES (NEW.id, COALESCE(NEW.email, 'user_' || NEW.id::text))
  ON CONFLICT (id) DO NOTHING;
  RETURN NEW;
END;
$$ LANGUAGE plpgsql SECURITY DEFINER;

CREATE TRIGGER on_auth_user_created
AFTER INSERT ON auth.users
FOR EACH ROW EXECUTE FUNCTION handle_new_user();
```

That would make the defensive upsert unnecessary. Tracked for a follow-up migration PR.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- To smoke test: after merge, click **Start New Branch** or **Fork New Branch** — should succeed and redirect to /play/<newBranchId>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)