### PR TITLE
fix(advance): skip past failed turn_commits when computing next turn_number

### DIFF
--- a/app/api/scenarios/[id]/branches/[branchId]/advance/route.ts
+++ b/app/api/scenarios/[id]/branches/[branchId]/advance/route.ts
@@ -354,16 +354,34 @@ export async function POST(
       .eq('id', (inProgress[0] as Record<string, unknown>).id as string)
   }
 
-  // ── Load head commit for turn number ────────────────────────────────────
+  // ── Load head commit for simulated_date ─────────────────────────────────
   const { data: headCommit } = await supabase
     .from('turn_commits')
     .select('turn_number, simulated_date')
     .eq('id', headCommitId)
     .single()
 
-  const prevTurn = (headCommit as Record<string, unknown> | null)?.turn_number as number ?? 0
+  const headTurn = (headCommit as Record<string, unknown> | null)?.turn_number as number ?? 0
   const prevDate = (headCommit as Record<string, unknown> | null)?.simulated_date as string ?? '2026-03-04'
-  const newTurnNumber = prevTurn + 1
+
+  // Compute next turn_number = max(turn_commits.turn_number on this branch) + 1.
+  // Falling back to head.turn_number + 1 for a fresh fork with no local commits yet.
+  //
+  // Why not just `head.turn_number + 1`? branches.head_commit_id only advances
+  // on successful pipeline completion. If a prior turn failed (marked 'failed'),
+  // the failed row still occupies (branch_id, head.turn_number + 1), and a retry
+  // would collide with unique_turn_per_branch. Using max-on-branch skips past
+  // failed rows.
+  const { data: lastBranchCommit } = await supabase
+    .from('turn_commits')
+    .select('turn_number')
+    .eq('branch_id', branchId)
+    .order('turn_number', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  const lastBranchTurn = (lastBranchCommit as { turn_number: number } | null)?.turn_number
+  const newTurnNumber = (lastBranchTurn ?? headTurn) + 1
   const newSimDate = advanceDate(prevDate, 7)
 
   // ── Insert turn_commit ──────────────────────────────────────────────────

--- a/tests/api/advance.test.ts
+++ b/tests/api/advance.test.ts
@@ -37,10 +37,17 @@ vi.mock('@/lib/supabase/service', () => ({
                 // head commit lookup: .select().eq('id', headCommitId).single()
                 return { single: vi.fn().mockResolvedValue({ data: { turn_number: 3, simulated_date: '2026-04-01' }, error: null }) }
               }
-              // duplicate-check query: .select().eq('branch_id', branchId).not(...).limit(1)
+              // Branch-scoped queries:
+              //  - duplicate-check: .select().eq('branch_id', branchId).not(...).limit(1)
+              //  - max turn_number:  .select().eq('branch_id', branchId).order(...).limit(1).maybeSingle()
               return {
                 single: mockSingleShared,
                 not: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: [], error: null }) })),
+                order: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                  })),
+                })),
               }
             }),
           })),


### PR DESCRIPTION
## Problem

Retrying a turn after a pipeline failure hit:
```
Failed to create turn: duplicate key value violates unique constraint "unique_turn_per_branch"
```

## Root cause

`branches.head_commit_id` only advances at successful pipeline completion. On failure, the catch block marks the `turn_commits` row as `current_phase: 'failed'` but leaves the row in the table and **does not** update `head_commit_id`.

So on retry, `/advance` recomputed `newTurnNumber = head.turn_number + 1` — the same number as the failed row. The insert then collided with `unique_turn_per_branch (branch_id, turn_number)`.

The duplicate-in-progress guard didn't catch this either — it filters to `current_phase NOT IN (complete, failed)`, so a row already marked `failed` is invisible to the guard.

## Fix

Compute next turn number from max on the branch, not from head commit:

```ts
const { data: lastBranchCommit } = await supabase
  .from('turn_commits')
  .select('turn_number')
  .eq('branch_id', branchId)
  .order('turn_number', { ascending: false })
  .limit(1)
  .maybeSingle()

const newTurnNumber = (lastBranchCommit?.turn_number ?? headTurn) + 1
```

For fresh forks (no commits yet on the new branch), falls back to `head.turn_number + 1`. Same answer as before in the happy path.

## Verification
- `npm run typecheck` clean
- `npm run lint` clean
- `tests/api/advance.test.ts` — both tests pass (test mock updated for the new query chain)
- Manual: retry after a pipeline failure should now succeed, producing a turn at N+2 (skipping the failed N+1)

## Follow-ups (not in this PR)

- `SET_TURN_ERROR` isn't cleared on the next `turn_started` broadcast. It's hidden by the DispatchTerminal's `isFailed` check so not user-visible, but worth clearing for hygiene.
- Could also delete the failed row in the duplicate-check block instead of skipping it. This PR picks 'skip past' — preserves debug history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)