### PR TITLE
fix: copy state snapshots on fork + resolve research test merge markers

### DIFF
--- a/app/api/branches/route.ts
+++ b/app/api/branches/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { resolveScenarioId } from '@/lib/supabase/resolve-scenario'
 import { DEV_TRUNK_BRANCH, DEV_ACTORS } from '@/lib/game/dev-branches'
+import { forkStateForBranch } from '@/lib/game/state-engine'
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -167,7 +168,34 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: error?.message ?? 'Insert failed' }, { status: 500 })
     }
 
-    return NextResponse.json({ id: data.id })
+    const newBranchId = (data as { id: string }).id
+
+    // Copy actor_state_snapshots and daily_depletion_rates from parent to new
+    // branch. Without this, /advance fails at getStateAtTurn with "No state
+    // snapshots found for branch X at turn Y" because snapshots live on the
+    // parent's branch_id, not the new one. Use the service client so we bypass
+    // the actor_state_snapshots RLS policy (writes are server-internal).
+    if (headCommitId && resolvedParentId) {
+      try {
+        await forkStateForBranch(
+          resolvedParentId,
+          headCommitId,
+          newBranchId,
+          { client: serviceClient },
+        )
+      } catch (forkErr) {
+        // Roll back the branch row so the user can retry cleanly instead of
+        // being stuck with a branch that has no state snapshots.
+        await serviceClient.from('branches').delete().eq('id', newBranchId)
+        const msg = forkErr instanceof Error ? forkErr.message : 'Unknown fork error'
+        return NextResponse.json(
+          { error: `Failed to copy parent branch state: ${msg}` },
+          { status: 500 },
+        )
+      }
+    }
+
+    return NextResponse.json({ id: newBranchId })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error'
     return NextResponse.json({ error: message }, { status: 500 })

--- a/tests/api/research-pipeline.test.ts
+++ b/tests/api/research-pipeline.test.ts
@@ -23,20 +23,7 @@ vi.mock("@/lib/supabase/server", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-<<<<<<< feat/unified-research-endpoint-31
-// Mock @/lib/supabase/service — used by persistPipelineResults in the pipeline
-// ---------------------------------------------------------------------------
-vi.mock("@/lib/supabase/service", () => ({
-  createServiceClient: vi.fn().mockReturnValue({
-    from: vi.fn().mockReturnValue({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({}) }),
-      }),
-      upsert: vi.fn().mockReturnValue({}),
-    }),
-  }),
-=======
-// Mock @/lib/supabase/service for persistPipelineResults (used after stages 1-6)
+// Mock @/lib/supabase/service — used by persistPipelineResults (stages 1–6)
 // ---------------------------------------------------------------------------
 vi.mock("@/lib/supabase/service", () => ({
   createServiceClient: vi.fn(() => ({
@@ -46,7 +33,6 @@ vi.mock("@/lib/supabase/service", () => ({
       eq: vi.fn().mockResolvedValue({ data: null, error: null }),
     }),
   })),
->>>>>>> main
 }));
 
 import { callClaude } from "@/lib/ai/anthropic";


### PR DESCRIPTION
## Problem 1 — Pipeline fails immediately on forked branches

After merging PRs #84 + #86 + #87, turn submission now starts but the pipeline fails at the planning phase. Root cause: `getStateAtTurn` throws "No state snapshots found for branch X at turn Y" because `actor_state_snapshots` rows still live under the **parent** branch's `branch_id`, not the newly forked branch. The fork insert only created the `branches` row — it didn't copy the state.

## Problem 2 — Stray merge conflict markers in research-pipeline.test.ts

`tests/api/research-pipeline.test.ts` has unresolved `<<<<<<<`/`=======`/`>>>>>>>` markers from a previous PR merge (`feat/unified-research-endpoint-31` vs `main`). Typecheck fails repo-wide. Needs a trivial conflict resolution regardless of this PR.

## Fix 1

After inserting the `branches` row, call `forkStateForBranch(parentId, forkCommitId, newBranchId, { client: serviceClient })`. That function already existed in `lib/game/state-engine.ts` — just wasn't being called from the route.

Uses the service client so writes bypass RLS on `actor_state_snapshots`. On fork-state failure, rolls back the branch insert so the user doesn't end up with an unplayable orphan branch.

## Fix 2

Resolved conflict by keeping the `main` side (`update.mockReturnThis() + upsert/eq as resolved promises`). Functionally equivalent to the `feat` side but the chain pattern matches what `persistPipelineResults` actually calls.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test -- --run tests/api/research-pipeline.test.ts tests/api/advance.test.ts` — 23/23 passing

## After merge

Create a fresh fork (not an existing one — your current fork still has no snapshots). Submit a turn. Should now progress past planning → resolving → judging → narrating → finalizing → complete.

Existing broken forks from before this PR: the simplest fix is to delete them from Supabase Studio and fork fresh. I can write a repair script if you'd prefer not to abandon them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)