### PR TITLE
feat(#52): Iran + Russia + China + Gulf States catalogs — consolidated, closes series

### DIFF
--- a/lib/game/decisions/china.ts
+++ b/lib/game/decisions/china.ts
@@ -1,0 +1,302 @@
+// lib/game/decisions/china.ts
+// China decision catalog for the Iran 2026 scenario.
+//
+// Strategic position (Turn 115):
+//   - ~45–50% of China's oil transits Hormuz — largest non-belligerent exposure
+//     (research-economic §1: "84% of oil and 83% of LNG shipped through Hormuz was bound for Asia")
+//   - Pre-war stockpiling: 1.2–1.4 billion barrels in strategic reserves (~120 days net imports)
+//   - China continues receiving ~1.25 mbd of Iranian oil at ~$8–10/bbl discount
+//   - USD share of global reserves declining from 72% (2001) to 57% (2025); yuan only 2%
+//   - China has de-escalated Taiwan pressure since conflict began (research-economic §4)
+//   - Special Envoy Zhai Jun conducting regional diplomatic tour from March 8
+//   - China positioning as alternative mediator/peace broker (research-political §5)
+//
+// Source files: docs/Iran Research/research-{economic,political,military}.md
+import type { DecisionOption, DecisionDetail } from '@/lib/types/panels'
+
+export const CN_DECISIONS: DecisionOption[] = [
+  {
+    id: 'cn-xi-mediation',
+    title: 'Xi-Led Mediation Initiative',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.3,
+  },
+  {
+    id: 'cn-yuan-settlement',
+    title: 'Accelerate Yuan Settlement for Iran Oil',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.35,
+  },
+  {
+    id: 'cn-spr-release',
+    title: 'Strategic Petroleum Reserve Release',
+    dimension: 'economic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.2,
+  },
+  {
+    id: 'cn-cyber-contractor',
+    title: 'Cyber Operations — US Defense Contractor Intrusion',
+    dimension: 'intelligence',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.4,
+  },
+  {
+    id: 'cn-un-narrative',
+    title: 'UN Narrative Campaign — "Peace & Development"',
+    dimension: 'information',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.15,
+  },
+  {
+    id: 'cn-taiwan-drills',
+    title: 'Taiwan / South China Sea Assertion',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.5,
+  },
+]
+
+export const CN_DECISION_DETAILS: Record<string, DecisionDetail> = {
+  'cn-xi-mediation': {
+    id: 'cn-xi-mediation',
+    title: 'Xi-Led Mediation Initiative',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.3,
+    strategicRationale:
+      'Beijing hosts a US-Iran summit brokered through Special Envoy Zhai Jun\'s ' +
+      'regional tour (active from March 8). China has offered an alternative ' +
+      'mediation role distinct from US/Western frameworks — "Peace & Development" ' +
+      'framing positions China as the responsible great power (research-political §5). ' +
+      'A successful summit breaks US claim that only Washington can end the conflict, ' +
+      'boosting Chinese soft power in the Global South.',
+    expectedOutcomes:
+      'Summit convened within 21 days if Iran agrees. Hormuz partial reopening ' +
+      'negotiable as a confidence-building measure. China gains a durable mediation ' +
+      'role comparable to the 2023 Saudi-Iran normalization deal it brokered.',
+    concurrencyRules: [
+      {
+        decisionId: 'cn-yuan-settlement',
+        decisionTitle: 'Accelerate Yuan Settlement for Iran Oil',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-taiwan-drills',
+        decisionTitle: 'Taiwan / South China Sea Assertion',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-cyber-contractor',
+        decisionTitle: 'Cyber Operations — US Defense Contractor Intrusion',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-un-narrative',
+        decisionTitle: 'UN Narrative Campaign — "Peace & Development"',
+        compatible: true,
+      },
+    ],
+  },
+
+  'cn-yuan-settlement': {
+    id: 'cn-yuan-settlement',
+    title: 'Accelerate Yuan Settlement for Iran Oil',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.35,
+    strategicRationale:
+      'Iran is actively considering allowing tankers to pass if cargo is traded in yuan ' +
+      '(CNN, March 14). China already settles nearly all of its ~1.25 mbd of Iranian oil ' +
+      'imports in yuan. Formalizing and publicizing this arrangement — and expanding it to ' +
+      'Chinese-flagged third-party shipments — operationalizes the yuan-for-oil wedge ' +
+      'into the dollar-denominated global oil market. The petrodollar "exorbitant privilege" ' +
+      'is worth ~$225–270B annually to the US; erosion compounds US fiscal strain at $1T+ ' +
+      'annual interest payments (research-economic §2).',
+    expectedOutcomes:
+      'Yuan share of oil payments rises from <5% toward 10–15% for China-corridor ' +
+      'shipments within 90 days. Dollar clearing for Chinese-Iran oil becomes de facto ' +
+      'optional, providing a replicable template for Russia and Gulf diversification. ' +
+      'US Treasury faces symbolic but concrete reserve-currency erosion signal.',
+    concurrencyRules: [
+      {
+        decisionId: 'cn-xi-mediation',
+        decisionTitle: 'Xi-Led Mediation Initiative',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-taiwan-drills',
+        decisionTitle: 'Taiwan / South China Sea Assertion',
+        compatible: true,
+      },
+      {
+        decisionId: 'cn-spr-release',
+        decisionTitle: 'Strategic Petroleum Reserve Release',
+        compatible: true,
+      },
+    ],
+  },
+
+  'cn-spr-release': {
+    id: 'cn-spr-release',
+    title: 'Strategic Petroleum Reserve Release',
+    dimension: 'economic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.2,
+    strategicRationale:
+      'China holds an estimated 1.2–1.4 billion barrels in strategic reserves — ' +
+      '~120 days of net imports — plus 40 million barrels in floating storage ' +
+      '(research-economic §4). Releasing 10 million barrels into Asian spot markets ' +
+      'demonstrates China\'s capacity to stabilize regional energy prices independently ' +
+      'of the IEA, which already authorized a 400M barrel emergency release on March 11. ' +
+      'A unilateral Chinese SPR release builds influence with import-dependent neighbors ' +
+      '(South Korea, Japan, India) without requiring military commitment.',
+    expectedOutcomes:
+      'Release of 10M bbl into Asian spot markets caps Brent at ~$130/bbl for ~60 days ' +
+      'on the Asian premium. South Korea\'s KOSPI circuit-breaker pressure eases. ' +
+      'China positions itself as a responsible stakeholder, softening Global South ' +
+      'criticism of Chinese neutrality.',
+    concurrencyRules: [
+      {
+        decisionId: 'cn-un-narrative',
+        decisionTitle: 'UN Narrative Campaign — "Peace & Development"',
+        compatible: true,
+      },
+      {
+        decisionId: 'cn-yuan-settlement',
+        decisionTitle: 'Accelerate Yuan Settlement for Iran Oil',
+        compatible: true,
+      },
+      {
+        decisionId: 'cn-taiwan-drills',
+        decisionTitle: 'Taiwan / South China Sea Assertion',
+        compatible: false,
+      },
+    ],
+  },
+
+  'cn-cyber-contractor': {
+    id: 'cn-cyber-contractor',
+    title: 'Cyber Operations — US Defense Contractor Intrusion',
+    dimension: 'intelligence',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.4,
+    strategicRationale:
+      'MSS-affiliated APT groups (Volt Typhoon, Salt Typhoon) maintain persistent ' +
+      'access to US defense contractor networks. With US attention on a two-theater ' +
+      'commitment (Iran + Ukraine support), operational security discipline degrades. ' +
+      'Tasking existing access toward Iran campaign planning — sortie schedules, ' +
+      'munitions inventory, strike sequencing — provides intelligence value to China ' +
+      'on US war-fighting capacity without direct military exposure. Secondary target: ' +
+      'Patriot and THAAD interceptor production data, relevant to Taiwan contingency planning ' +
+      '(research-economic §4: US burned 14% of THAAD stockpile against Iran in six days).',
+    expectedOutcomes:
+      'Campaign-planning documents exfiltrated within 14–21 days. US munitions-depletion ' +
+      'rate becomes a known quantity for PLA planning cycles. If discovered, operation is ' +
+      'deniable — APT attribution standard is "probable" not "proven." Risk: if publicized ' +
+      'during the conflict, US may use it as justification for Hormuz coalition hardening.',
+    concurrencyRules: [
+      {
+        decisionId: 'cn-xi-mediation',
+        decisionTitle: 'Xi-Led Mediation Initiative',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-un-narrative',
+        decisionTitle: 'UN Narrative Campaign — "Peace & Development"',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-taiwan-drills',
+        decisionTitle: 'Taiwan / South China Sea Assertion',
+        compatible: true,
+      },
+    ],
+  },
+
+  'cn-un-narrative': {
+    id: 'cn-un-narrative',
+    title: 'UN Narrative Campaign — "Peace & Development"',
+    dimension: 'information',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.15,
+    strategicRationale:
+      'China frames the conflict through the Non-Aligned Movement lens: US-Israeli ' +
+      'strikes violated UN Charter Article 2(4) with no Security Council authorization. ' +
+      'Wang Yi\'s statement — "the killing of Khamenei is unacceptable" — and Foreign ' +
+      'Minister condemnations of unilateral US action are already on record ' +
+      '(research-economic §4). A structured UN narrative campaign, coordinated with ' +
+      'BRICS partners and Global South ambassadors, amplifies the "rules-based order" ' +
+      'hypocrisy framing. Research-political §5: China offered mediation, positioning ' +
+      'itself as the responsible alternative to US unilateralism.',
+    expectedOutcomes:
+      'UNGA emergency session motion passes with 120+ affirmative votes. China-authored ' +
+      '"ceasefire and dialogue" resolution placed in the record even if US vetoes it in ' +
+      'the Security Council. Global South credibility for China rises, weakening the ' +
+      'US-led post-conflict reconstruction narrative.',
+    concurrencyRules: [
+      {
+        decisionId: 'cn-spr-release',
+        decisionTitle: 'Strategic Petroleum Reserve Release',
+        compatible: true,
+      },
+      {
+        decisionId: 'cn-xi-mediation',
+        decisionTitle: 'Xi-Led Mediation Initiative',
+        compatible: true,
+      },
+      {
+        decisionId: 'cn-cyber-contractor',
+        decisionTitle: 'Cyber Operations — US Defense Contractor Intrusion',
+        compatible: false,
+      },
+    ],
+  },
+
+  'cn-taiwan-drills': {
+    id: 'cn-taiwan-drills',
+    title: 'Taiwan / South China Sea Assertion',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.5,
+    strategicRationale:
+      'Attested Chinese pattern: coordinate gray-zone moves with US distraction. ' +
+      'The December 2025 "Justice Mission" drills rehearsed a full maritime blockade ' +
+      'of Taiwan. THAAD components have been removed from South Korea (research-economic §4). ' +
+      'USS Tripoli ARG redeployed to CENTCOM. The USS George Washington remains in Japan, ' +
+      'but US munitions stockpiles are at historic lows. Resuming ADIZ incursions and ' +
+      'conducting coordinated PLA air-naval exercises near Taiwan sends a Taiwan Strait ' +
+      'signal without crossing kinetic thresholds, recalibrating deterrence during a window ' +
+      'when US two-theater capacity is visibly strained.',
+    expectedOutcomes:
+      'Taiwan declares heightened alert. US Pacific Command issues a statement but cannot ' +
+      'credibly reinforce given current theater commitments. China gains a deterrence data ' +
+      'point on US response thresholds with reduced asset exposure. Risk: if the US uses ' +
+      'this as a pretext to de-escalate in Iran to pivot east, China\'s window in both ' +
+      'theaters narrows simultaneously.',
+    concurrencyRules: [
+      {
+        decisionId: 'cn-xi-mediation',
+        decisionTitle: 'Xi-Led Mediation Initiative',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-yuan-settlement',
+        decisionTitle: 'Accelerate Yuan Settlement for Iran Oil',
+        compatible: true,
+      },
+      {
+        decisionId: 'cn-spr-release',
+        decisionTitle: 'Strategic Petroleum Reserve Release',
+        compatible: false,
+      },
+      {
+        decisionId: 'cn-cyber-contractor',
+        decisionTitle: 'Cyber Operations — US Defense Contractor Intrusion',
+        compatible: true,
+      },
+    ],
+  },
+}

--- a/lib/game/decisions/gulf-states.ts
+++ b/lib/game/decisions/gulf-states.ts
@@ -1,0 +1,266 @@
+// lib/game/decisions/gulf-states.ts
+// Gulf Cooperation Council (GCC) States decision catalog for the Iran 2026 scenario.
+// Models GCC as a COLLECTIVE actor; decisions reflect weighted consensus positions
+// across Saudi Arabia, UAE, Qatar, Kuwait, Bahrain, and Oman.
+//
+// Current state (turn 115):
+// - Iran has struck all six GCC members (political §4: 2,000+ missiles/drones)
+// - Saudi + UAE trust in US is shattered (US bases used without full consultation)
+// - Dubai real estate equities down ~30%; tourism losing $600M/day (political §4)
+// - Backchannel diplomacy with Iran persists despite attacks (political §4)
+// - GCC is NOT unified: Qatar hosts Al Udeid; Oman is mediator; SA/UAE/Bahrain direct victims
+// - Saudi-Iran March 2023 rapprochement technically still in effect (political §4)
+//
+// Source: docs/Iran Research/research-{political,economic,military}.md
+import type { DecisionOption, DecisionDetail } from '@/lib/types/panels'
+
+export const GCC_DECISIONS: DecisionOption[] = [
+  {
+    id: 'gcc-deny-airbases',
+    title: 'Deny US Further Use of Airbases for Strikes on Iran',
+    dimension: 'political',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.3,
+  },
+  {
+    id: 'gcc-oman-backchannel',
+    title: 'Activate Oman Backchannel — Full-Spectrum Talks',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.2,
+  },
+  {
+    id: 'gcc-opec-adjustment',
+    title: 'OPEC+ Production Adjustment — Price Stabilization',
+    dimension: 'economic',
+    escalationDirection: 'neutral',
+    resourceWeight: 0.35,
+  },
+  {
+    id: 'gcc-swf-divestment',
+    title: 'Sovereign Fund Divestment — US Treasuries',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.4,
+  },
+  {
+    id: 'gcc-saudi-iran-bilateral',
+    title: 'Saudi-Iran Direct Bilateral Talks',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.25,
+  },
+  {
+    id: 'gcc-security-summit',
+    title: 'Emergency Regional Security Summit — GCC+Jordan+Egypt+Turkey',
+    dimension: 'diplomatic',
+    escalationDirection: 'neutral',
+    resourceWeight: 0.2,
+  },
+]
+
+export const GCC_DECISION_DETAILS: Record<string, DecisionDetail> = {
+  'gcc-deny-airbases': {
+    id: 'gcc-deny-airbases',
+    title: 'Deny US Further Use of Airbases for Strikes on Iran',
+    dimension: 'political',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.3,
+    strategicRationale:
+      'Gulf states explicitly told the US their territory could not be used for strikes on Iran (Fox News/WSJ: blocked base and airspace access late January 2026). Despite being overridden, Iran struck all six GCC members in retaliation for hosting US forces — killing dozens, setting ablaze the Ras Tanura refinery, forcing Qatar force majeure on LNG, striking US Fifth Fleet base in Bahrain. A formal GCC communiqué formalizing a cap on US offensive operational tempo distances GCC from co-belligerent status, reduces the targeting rationale for further Iranian strikes, and reasserts sovereign control over territory. Consistent with Vice Adm. Harward assessment: "We have failed to earn the trust and confidence of our Gulf partners." (political §4)',
+    expectedOutcomes:
+      'Estimated 40–60% reduction in Iranian targeting of GCC infrastructure within 14 days of communiqué. Reduces risk of further Ras Tanura or LNG strikes. Expected US diplomatic friction — potential review of defence guarantees for 1–2 GCC states. Does NOT terminate existing US basing agreements; restricts offensive sortie authorisation only.',
+    concurrencyRules: [
+      {
+        decisionId: 'gcc-oman-backchannel',
+        decisionTitle: 'Activate Oman Backchannel — Full-Spectrum Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-opec-adjustment',
+        decisionTitle: 'OPEC+ Production Adjustment — Price Stabilization',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-saudi-iran-bilateral',
+        decisionTitle: 'Saudi-Iran Direct Bilateral Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-swf-divestment',
+        decisionTitle: 'Sovereign Fund Divestment — US Treasuries',
+        compatible: true,
+      },
+    ],
+  },
+
+  'gcc-oman-backchannel': {
+    id: 'gcc-oman-backchannel',
+    title: 'Activate Oman Backchannel — Full-Spectrum Talks',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.2,
+    strategicRationale:
+      'Oman hosted indirect US-Iran talks (February 6, 2026) that came "close to a genuine breakthrough" — Omani FM Al Busaidi declared peace was "within reach" two days before the strikes. Sultan Haitham has offered to host direct talks. The Soufan Center assesses Gulf and Iranian diplomats are "back-channeling on how to prevent further Iranian attacks." GCC states are preparing for the scenario where the Iranian regime survives, making a durable communication channel a strategic asset regardless of war outcome. Qatar — GCC member that shot down two Iranian jets — also maintains separate channels. Expansion from ceasefire-focused messaging to a comprehensive framework (infrastructure targeting halt, IRGC-GCC deconfliction, post-war economic guarantees) raises the stakes and credibility. (political §4)',
+    expectedOutcomes:
+      'Framework agenda within 7–10 days. Mutual ceasefire on GCC-targeting strikes achievable within 21 days if both sides engage. Oman mediation restores pre-war "within reach" status. Qatar LNG force majeure lifted once Ras Laffan targeting ceases — restoring up to 77 million tonnes per annum and $2–3B/month in Qatari revenue.',
+    concurrencyRules: [
+      {
+        decisionId: 'gcc-deny-airbases',
+        decisionTitle: 'Deny US Further Use of Airbases for Strikes on Iran',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-swf-divestment',
+        decisionTitle: 'Sovereign Fund Divestment — US Treasuries',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-saudi-iran-bilateral',
+        decisionTitle: 'Saudi-Iran Direct Bilateral Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-security-summit',
+        decisionTitle: 'Emergency Regional Security Summit — GCC+Jordan+Egypt+Turkey',
+        compatible: true,
+      },
+    ],
+  },
+
+  'gcc-opec-adjustment': {
+    id: 'gcc-opec-adjustment',
+    title: 'OPEC+ Production Adjustment — Price Stabilization',
+    dimension: 'economic',
+    escalationDirection: 'neutral',
+    resourceWeight: 0.35,
+    strategicRationale:
+      'Saudi Arabia holds ~3 million bpd spare capacity; UAE adds ~440,000 bpd via ADCOP bypass. With Brent at $108.78/bbl (March 18, peaked $119.48 on March 12) and IEA warning of the "largest supply disruption in history," a coordinated OPEC+ production increase caps oil at ~$115/bbl, avoiding a US recession that would crater Gulf export revenue and invite political backlash threatening long-term security ties. Saudi East-West Pipeline (Petroline) is already at ~2.2M bpd (up from 1.1M). The $600M/day in tourism losses and DFM closures signal that economic instability hurts GCC economies even as headline prices rise. Price stabilisation at $115/bbl preserves Saudi/UAE revenue while removing Iran\'s Hormuz leverage narrative. (economic §1)',
+    expectedOutcomes:
+      'Coordinated production surge of 1.5–2.5M bpd achievable within 30 days. Oil price cap at $110–115/bbl. Reduces Iran\'s Hormuz closure leverage: at $115/bbl Iran extracts ~$55B/yr less than at $130/bbl. US gas prices stabilise at $3.60–3.80/gallon — below recession trigger threshold. Does NOT break OPEC+ agreement; structured as emergency price-management mechanism consistent with 2022 precedents.',
+    concurrencyRules: [
+      {
+        decisionId: 'gcc-deny-airbases',
+        decisionTitle: 'Deny US Further Use of Airbases for Strikes on Iran',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-security-summit',
+        decisionTitle: 'Emergency Regional Security Summit — GCC+Jordan+Egypt+Turkey',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-swf-divestment',
+        decisionTitle: 'Sovereign Fund Divestment — US Treasuries',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-oman-backchannel',
+        decisionTitle: 'Activate Oman Backchannel — Full-Spectrum Talks',
+        compatible: true,
+      },
+    ],
+  },
+
+  'gcc-swf-divestment': {
+    id: 'gcc-swf-divestment',
+    title: 'Sovereign Fund Divestment — US Treasuries',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.4,
+    strategicRationale:
+      'Gulf sovereign wealth funds collectively manage >$2 trillion in US assets (FT, March 5). At least three of four major Gulf economies have begun internal reviews of overseas investment commitments, examining force majeure clauses. An adviser to a Gulf government told the FT this prospect "already caught the White House\'s attention." The petrodollar system generates ~$225–270B annually in US borrowing advantages. A visible rotation of even 5–10% of Gulf SWF holdings ($100–200B) from US Treasuries into euro-denominated bonds, yuan instruments, or gold signals strategic displeasure without triggering a market crash — but demonstrates that the "betrayal" narrative (political §4) has material consequences. The $7B China-Saudi currency swap is an existing channel. (economic §2, political §4)',
+    expectedOutcomes:
+      'Signal rotation of $50–100B out of US Treasuries over 90 days raises 10-year US yields by an estimated 10–20 basis points. White House receives clear political signal. Yuan-denominated holdings rise from near-zero to 3–5% of total SWF allocation. Petrodollar erosion accelerates by 2–3 years vs. baseline trajectory. Reversible: rotation can be paused or reversed within 30 days if US adjusts posture.',
+    concurrencyRules: [
+      {
+        decisionId: 'gcc-oman-backchannel',
+        decisionTitle: 'Activate Oman Backchannel — Full-Spectrum Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-deny-airbases',
+        decisionTitle: 'Deny US Further Use of Airbases for Strikes on Iran',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-opec-adjustment',
+        decisionTitle: 'OPEC+ Production Adjustment — Price Stabilization',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-saudi-iran-bilateral',
+        decisionTitle: 'Saudi-Iran Direct Bilateral Talks',
+        compatible: true,
+      },
+    ],
+  },
+
+  'gcc-saudi-iran-bilateral': {
+    id: 'gcc-saudi-iran-bilateral',
+    title: 'Saudi-Iran Direct Bilateral Talks',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.25,
+    strategicRationale:
+      'Iran publicly expressed appreciation to Saudi Arabia (March 5) for upholding commitments not to allow Saudi territory to be used against Iran — indicating both sides preserve a functional diplomatic channel. The March 2023 Beijing-brokered Saudi-Iran rapprochement is technically in effect despite Saudi FM describing attacks as "brazen and cowardly." Multiple sources indicate diplomatic communications continue. Gulf officials told the Jerusalem Post: "It\'s possible that in the end, the regime will not fall… Gulf states would have to continue dealing with Tehran." MBS-to-Pezeshkian-successor channel bypasses US entirely, establishing a parallel peace track that protects GCC interests regardless of US-Iran outcome. Precedent: Saudi-Iran 2023 deal achieved without US involvement. (political §4)',
+    expectedOutcomes:
+      'Mutual pledge of no further strikes on civilian infrastructure (Ras Tanura, Ras Laffan, Mussafah) within 10–14 days. Saudi Aramco Ras Tanura refinery (550,000 bpd) returns to operations within 21 days. Reduces operational risk premium on Gulf oil by $8–12/bbl. Does not constitute a formal ceasefire — preserves Iranian ability to strike US/Israeli assets while protecting GCC economic infrastructure.',
+    concurrencyRules: [
+      {
+        decisionId: 'gcc-deny-airbases',
+        decisionTitle: 'Deny US Further Use of Airbases for Strikes on Iran',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-oman-backchannel',
+        decisionTitle: 'Activate Oman Backchannel — Full-Spectrum Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-swf-divestment',
+        decisionTitle: 'Sovereign Fund Divestment — US Treasuries',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-security-summit',
+        decisionTitle: 'Emergency Regional Security Summit — GCC+Jordan+Egypt+Turkey',
+        compatible: true,
+      },
+    ],
+  },
+
+  'gcc-security-summit': {
+    id: 'gcc-security-summit',
+    title: 'Emergency Regional Security Summit — GCC+Jordan+Egypt+Turkey',
+    dimension: 'diplomatic',
+    escalationDirection: 'neutral',
+    resourceWeight: 0.2,
+    strategicRationale:
+      'Chatham House assessed: "Whatever was left of that trust has been broken, accelerating the GCC states\' push to diversify security partners." Russia, China, and Iran conducted joint naval drills in the Strait of Hormuz in February 2026. Analyst Hussein Ibish captured the mood: "Three layers: first is rage against Iran, second is dismay with Washington, and third is profound suspicion about Israel\'s regional agenda." An expanded forum — GCC plus Jordan, Egypt, and Turkey — creates a non-US, non-Israeli regional security architecture. Turkey is NATO but has independent Middle East policy; Egypt controls the Suez Canal; Jordan has exposed borders. The forum agenda: coordinated air defence burden-sharing, joint ceasefire demand, and a post-war reconstruction compact for Gulf infrastructure ($15B in losses in first two weeks). (political §4)',
+    expectedOutcomes:
+      'Summit convened within 14–21 days. Joint communiqué calling for ceasefire issued by 8–10 regional states. Coordinated air defence sharing reduces per-country cost by 20–30%. Establishes permanent secretariat as seed of a post-war regional security architecture independent of US Fifth Fleet dependence. Turkey engagement keeps NATO signalling channel open without subordinating GCC to Washington.',
+    concurrencyRules: [
+      {
+        decisionId: 'gcc-opec-adjustment',
+        decisionTitle: 'OPEC+ Production Adjustment — Price Stabilization',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-oman-backchannel',
+        decisionTitle: 'Activate Oman Backchannel — Full-Spectrum Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-saudi-iran-bilateral',
+        decisionTitle: 'Saudi-Iran Direct Bilateral Talks',
+        compatible: true,
+      },
+      {
+        decisionId: 'gcc-deny-airbases',
+        decisionTitle: 'Deny US Further Use of Airbases for Strikes on Iran',
+        compatible: true,
+      },
+    ],
+  },
+}

--- a/lib/game/decisions/index.ts
+++ b/lib/game/decisions/index.ts
@@ -5,6 +5,10 @@
 import type { DecisionOption, DecisionDetail } from '@/lib/types/panels'
 import { US_DECISIONS, US_DECISION_DETAILS } from './united-states'
 import { IL_DECISIONS, IL_DECISION_DETAILS } from './israel'
+import { IR_DECISIONS, IR_DECISION_DETAILS } from './iran'
+import { RU_DECISIONS, RU_DECISION_DETAILS } from './russia'
+import { CN_DECISIONS, CN_DECISION_DETAILS } from './china'
+import { GCC_DECISIONS, GCC_DECISION_DETAILS } from './gulf-states'
 
 // Actor IDs match scenario_actors.id values used in scripts/seed-iran.ts.
 export type ActorId =
@@ -18,19 +22,19 @@ export type ActorId =
 /** Decisions a given actor can choose from each turn, keyed by actor_id. */
 export const DECISION_CATALOG: Record<ActorId, DecisionOption[]> = {
   united_states: US_DECISIONS,
-  iran: [],
+  iran: IR_DECISIONS,
   israel: IL_DECISIONS,
-  russia: [],
-  china: [],
-  gulf_states: [],
+  russia: RU_DECISIONS,
+  china: CN_DECISIONS,
+  gulf_states: GCC_DECISIONS,
 }
 
 /** Detail metadata (rationale, outcomes, concurrency) keyed by actor then decision id. */
 export const DECISION_DETAILS: Record<ActorId, Record<string, DecisionDetail>> = {
   united_states: US_DECISION_DETAILS,
-  iran: {},
+  iran: IR_DECISION_DETAILS,
   israel: IL_DECISION_DETAILS,
-  russia: {},
-  china: {},
-  gulf_states: {},
+  russia: RU_DECISION_DETAILS,
+  china: CN_DECISION_DETAILS,
+  gulf_states: GCC_DECISION_DETAILS,
 }

--- a/lib/game/decisions/iran.ts
+++ b/lib/game/decisions/iran.ts
@@ -1,0 +1,346 @@
+// lib/game/decisions/iran.ts
+// Iran decision catalog for the Iran 2026 scenario (turn 115).
+// Scenario state: Khamenei killed Feb 28; Mojtaba appointed Mar 8; nuclear program degraded
+// but not eliminated; ~1,000–1,200 ballistic missiles remaining; Hormuz effectively closed;
+// IRGC's 31 semi-autonomous provincial commands still functioning.
+// Sources: docs/Iran Research/research-{military,political,economic}.md
+import type { DecisionOption, DecisionDetail } from '@/lib/types/panels'
+
+// NOTE: Exported as IR_DECISIONS / IR_DECISION_DETAILS to avoid collision with the
+// backwards-compat shim in lib/game/iran-decisions.ts (which re-exports US_DECISIONS
+// under the alias IRAN_DECISIONS).
+export const IR_DECISIONS: DecisionOption[] = [
+  {
+    id: 'ballistic-strike-gulf-bases',
+    title: 'Ballistic Missile Strike — Gulf Bases',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.6,
+    requiredAssets: [
+      { assetType: 'ballistic_missiles_reserve', requiredStatus: ['available'] },
+    ],
+  },
+  {
+    id: 'close-strait-hormuz',
+    title: 'Close Strait of Hormuz',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.55,
+    requiredAssets: [
+      { assetType: 'irgc_naval_fast_attack', requiredStatus: ['available'] },
+    ],
+  },
+  {
+    id: 'seek-russian-chinese-mediation',
+    title: 'Seek Russian/Chinese Mediation',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.15,
+  },
+  {
+    id: 'nuclear-reconstitution',
+    title: 'Accelerate Nuclear Reconstitution',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.5,
+    requiredAssets: [
+      { assetType: 'centrifuge_manufacturing_capacity', requiredStatus: ['available'] },
+    ],
+  },
+  {
+    id: 'martyr-state-propaganda',
+    title: 'Propaganda Campaign — "Martyr State"',
+    dimension: 'information',
+    escalationDirection: 'neutral',
+    resourceWeight: 0.2,
+  },
+  {
+    id: 'activate-proxies-houthi-hezbollah',
+    title: 'Activate Houthi / Hezbollah Proxies',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.45,
+  },
+]
+
+export const IR_DECISION_DETAILS: Record<string, DecisionDetail> = {
+  'ballistic-strike-gulf-bases': {
+    id: 'ballistic-strike-gulf-bases',
+    title: 'Ballistic Missile Strike — Gulf Bases',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.6,
+    strategicRationale:
+      'Iran retains an estimated 1,000–1,200 ballistic missiles after the Feb 28–Mar 18 exchange' +
+      ' (Haaretz; ~500+ fired, ~75% of launchers destroyed by CENTCOM). Targeting Al Udeid (Qatar),' +
+      ' Ain al-Assad (Iraq), and USS Abraham Lincoln in the Arabian Sea exploits the confirmed cost' +
+      ' asymmetry: each Shahab or Kheibar Shekan costs $2–5M while a single THAAD interceptor' +
+      ' costs $12–15M and US stocks are projected to exhaust in 4–5 weeks at current engagement' +
+      ' rates (research-military §10, §2). Fattah-2 hypersonic glide vehicles (Mach 13–15,' +
+      ' combat-debut March 1) can defeat SM-6 interceptors and represent Iran\'s highest-value' +
+      ' "rationed" reserve for this scenario.',
+    expectedOutcomes:
+      'A saturation volley of 60–80 missiles divided across 3 targets inflicts' +
+      ' THAAD/Patriot depletion on at least one battery, potentially disabling the Al Udeid' +
+      ' AN/FPS-132 early-warning radar ($1.1B asset, already damaged). Probability of US/coalition' +
+      ' fatalities is high (>80%), triggering a domestic US escalation response while depleting' +
+      ' 5–8% of remaining US interceptor inventory. Iran expends ~8–10% of its remaining' +
+      ' missile reserve; resupply from covert production lines is 50–100 missiles/month.',
+    concurrencyRules: [
+      {
+        decisionId: 'seek-russian-chinese-mediation',
+        decisionTitle: 'Seek Russian/Chinese Mediation',
+        compatible: false,
+      },
+      {
+        decisionId: 'nuclear-reconstitution',
+        decisionTitle: 'Accelerate Nuclear Reconstitution',
+        compatible: true,
+      },
+      {
+        decisionId: 'martyr-state-propaganda',
+        decisionTitle: 'Propaganda Campaign — "Martyr State"',
+        compatible: true,
+      },
+      {
+        decisionId: 'activate-proxies-houthi-hezbollah',
+        decisionTitle: 'Activate Houthi / Hezbollah Proxies',
+        compatible: true,
+      },
+    ],
+  },
+
+  'close-strait-hormuz': {
+    id: 'close-strait-hormuz',
+    title: 'Close Strait of Hormuz',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.55,
+    strategicRationale:
+      'Iran began planting naval mines around March 10 and the IRGC officially declared the Strait' +
+      ' "closed" on March 2 — already in effect for US/Western-aligned shipping (research-military' +
+      ' §11; research-economic §1). The strait carries ~20 million bpd (~20% of global petroleum' +
+      ' consumption), and China receives 45–50% of its oil via this chokepoint. Only 3.5–5.5M bpd' +
+      ' of alternative pipeline capacity exists — wholly insufficient. Iran holds an estimated' +
+      ' 5,000–6,000 naval mines and IRGC fast-attack swarms. Tightening the closure by expanding' +
+      ' minefields and interdicting neutral tankers raises global oil from $108/bbl toward the' +
+      ' $120–130/bbl JP Morgan threshold, maximizing economic leverage on China and Europe to' +
+      ' pressure Washington for a ceasefire (research-economic §3).',
+    expectedOutcomes:
+      'Full mine-field expansion reduces transits from ~21 tankers/week to near zero within 48 hours.' +
+      ' Brent crude re-tests $119–126/bbl peak. China, which has maintained back-channel' +
+      ' communications with Iran (research-political §4 Gulf states section), faces $40B/month' +
+      ' import-cost increase — increasing Beijing\'s incentive to lean on Washington. Marine-clearance' +
+      ' operations take months; Iran absorbs ~$1.5B/day in its own lost oil revenue but this is' +
+      ' offset by leverage value. Risk: US Tripoli amphibious group (~2,200 Marines) accelerates' +
+      ' toward Strait seizure mission.',
+    concurrencyRules: [
+      {
+        decisionId: 'seek-russian-chinese-mediation',
+        decisionTitle: 'Seek Russian/Chinese Mediation',
+        compatible: false,
+      },
+      {
+        decisionId: 'ballistic-strike-gulf-bases',
+        decisionTitle: 'Ballistic Missile Strike — Gulf Bases',
+        compatible: true,
+      },
+      {
+        decisionId: 'activate-proxies-houthi-hezbollah',
+        decisionTitle: 'Activate Houthi / Hezbollah Proxies',
+        compatible: true,
+      },
+      {
+        decisionId: 'martyr-state-propaganda',
+        decisionTitle: 'Propaganda Campaign — "Martyr State"',
+        compatible: true,
+      },
+    ],
+  },
+
+  'seek-russian-chinese-mediation': {
+    id: 'seek-russian-chinese-mediation',
+    title: 'Seek Russian/Chinese Mediation',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.15,
+    strategicRationale:
+      'Mojtaba Khamenei was reportedly transported to Moscow on a Russian military plane around' +
+      ' March 16 (research-political §2 succession section). Russia has been providing Iran with' +
+      ' intelligence on US warship positions (Washington Post, 3 US officials; research-political' +
+      ' §4). Domestic opposition is fragmented and "unable to capitalize" (Time, March 16); no' +
+      ' organized exile faction has street-level support inside Iran. A formal request for' +
+      ' Russian/Chinese good-offices offers Mojtaba legitimacy, halts the command decapitation' +
+      ' spiral, and exploits Beijing\'s strategic interest in resuming Hormuz oil flows — all' +
+      ' without surrendering the nuclear dossier (research-political §2).',
+    expectedOutcomes:
+      'If Moscow brokers a 72-hour ceasefire framework, Iranian missile attacks pause and oil' +
+      ' markets correct by 15–20%. Mojtaba consolidates IRGC loyalty by demonstrating the new' +
+      ' leadership can maneuver diplomatically. Risk: Washington may reject third-party mediation' +
+      ' as it did Oman\'s February 26 breakthrough, and the window may close in <48 hours if' +
+      ' US strikes accelerate. Iranian concessions required: likely some enriched uranium transfer' +
+      ' and IAEA access to undamaged sites.',
+    concurrencyRules: [
+      {
+        decisionId: 'ballistic-strike-gulf-bases',
+        decisionTitle: 'Ballistic Missile Strike — Gulf Bases',
+        compatible: false,
+      },
+      {
+        decisionId: 'close-strait-hormuz',
+        decisionTitle: 'Close Strait of Hormuz',
+        compatible: false,
+      },
+      {
+        decisionId: 'nuclear-reconstitution',
+        decisionTitle: 'Accelerate Nuclear Reconstitution',
+        compatible: false,
+      },
+      {
+        decisionId: 'martyr-state-propaganda',
+        decisionTitle: 'Propaganda Campaign — "Martyr State"',
+        compatible: true,
+      },
+    ],
+  },
+
+  'nuclear-reconstitution': {
+    id: 'nuclear-reconstitution',
+    title: 'Accelerate Nuclear Reconstitution',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.5,
+    strategicRationale:
+      'The IAEA stated on February 27, 2026 that it "cannot provide any information on the' +
+      ' current size, composition or whereabouts of the stockpile of enriched uranium" — Iran' +
+      ' retains ~440 kg of 60%-enriched uranium, enough for ~10 weapons if further enriched,' +
+      ' and IAEA lost centrifuge manufacturing verification in 2021 (research-military §4).' +
+      ' Satellite imagery shows Iran accelerating work on Pickaxe Mountain, an underground site' +
+      ' buried >100 meters — deeper than Fordow and potentially impervious to GBU-57 MOPs.' +
+      ' With Khamenei\'s fatwa effectively void at his death (research-military §4) and both' +
+      ' pre-war constraints eliminated, Mojtaba (assessed as "more favorable to nuclear weapons" — ' +
+      ' Washington Institute) has strategic and political incentive to covertly reconstitute.',
+    expectedOutcomes:
+      'Diverting centrifuge cascades rescued from Natanz/Fordow to Pickaxe Mountain and a second' +
+      ' covert site shortens breakout timeline from "months to a year" to potentially 4–6 weeks' +
+      ' once weapons-grade enrichment resumes. Achieves deterrence value before the end of the' +
+      ' current 19-day conflict. If detected, triggers immediate US/Israeli strike authorization;' +
+      ' if undetected for 30+ days, IAEA verification becomes virtually impossible.',
+    concurrencyRules: [
+      {
+        decisionId: 'seek-russian-chinese-mediation',
+        decisionTitle: 'Seek Russian/Chinese Mediation',
+        compatible: false,
+      },
+      {
+        decisionId: 'ballistic-strike-gulf-bases',
+        decisionTitle: 'Ballistic Missile Strike — Gulf Bases',
+        compatible: true,
+      },
+      {
+        decisionId: 'martyr-state-propaganda',
+        decisionTitle: 'Propaganda Campaign — "Martyr State"',
+        compatible: true,
+      },
+      {
+        decisionId: 'activate-proxies-houthi-hezbollah',
+        decisionTitle: 'Activate Houthi / Hezbollah Proxies',
+        compatible: true,
+      },
+    ],
+  },
+
+  'martyr-state-propaganda': {
+    id: 'martyr-state-propaganda',
+    title: 'Propaganda Campaign — "Martyr State"',
+    dimension: 'information',
+    escalationDirection: 'neutral',
+    resourceWeight: 0.2,
+    strategicRationale:
+      'Iranian public sentiment is divided, not unified: some Iranians celebrated Khamenei\'s death' +
+      ' in Isfahan, Karaj, and Shiraz; diaspora protests drew 350,000 in Los Angeles and Toronto' +
+      ' (research-political §2). The regime is "using wartime conditions to suppress all dissent' +
+      ' as treason" (Carnegie Endowment). Framing the conflict as unprovoked Western aggression' +
+      ' against a sovereign Islamic nation — emphasizing the Jan 2026 massacre cover-up, civilian' +
+      ' casualties, and the killing of Khamenei one day after Oman\'s diplomatic breakthrough —' +
+      ' targets the nationalist segment of the divided population and exploits anti-war opinion' +
+      ' in the US (40–60% opposition; research-political §1) and among Global South audiences.',
+    expectedOutcomes:
+      'A sustained 2-week campaign across state media, social channels, and Al Jazeera sympathizers' +
+      ' raises pro-regime rally-around-the-flag sentiment by an estimated 10–15 percentage points' +
+      ' among wavering Iranians, reducing active collaboration with US intelligence networks.' +
+      ' Internationally, drives UNGA emergency session rhetoric and increases pressure on US' +
+      ' allies to distance themselves from the conflict. Does not require any military resource' +
+      ' expenditure; compatible with most concurrent decisions.',
+    concurrencyRules: [
+      {
+        decisionId: 'ballistic-strike-gulf-bases',
+        decisionTitle: 'Ballistic Missile Strike — Gulf Bases',
+        compatible: true,
+      },
+      {
+        decisionId: 'close-strait-hormuz',
+        decisionTitle: 'Close Strait of Hormuz',
+        compatible: true,
+      },
+      {
+        decisionId: 'nuclear-reconstitution',
+        decisionTitle: 'Accelerate Nuclear Reconstitution',
+        compatible: true,
+      },
+      {
+        decisionId: 'seek-russian-chinese-mediation',
+        decisionTitle: 'Seek Russian/Chinese Mediation',
+        compatible: true,
+      },
+    ],
+  },
+
+  'activate-proxies-houthi-hezbollah': {
+    id: 'activate-proxies-houthi-hezbollah',
+    title: 'Activate Houthi / Hezbollah Proxies',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.45,
+    strategicRationale:
+      'The IRGC\'s "Axis of Resistance" network continues operating despite command decapitation.' +
+      ' Hezbollah re-entered the war March 2 firing ~100 rockets/day and Israel launched its' +
+      ' largest Lebanon ground invasion since 2006 on March 16, deploying the 91st Division' +
+      ' across three armored/infantry formations (research-military §12). Houthis have' +
+      ' demonstrated the ability to strike Gulf oil infrastructure and Red Sea shipping' +
+      ' (research-military §11 — Ras Laffan hit, Mesaieed Industrial Area struck).' +
+      ' Coordinated multi-front pressure forces Israel to split Iron Dome/David\'s Sling intercept' +
+      ' capacity across northern Lebanon and the south, while stretching US naval escort' +
+      ' resources across the Red Sea and Arabian Gulf simultaneously.',
+    expectedOutcomes:
+      'Hezbollah multi-rocket salvos (100–200/day escalating to 300+) combined with Houthi' +
+      ' anti-ship missile attacks on Red Sea corridor reduce Israeli northern front defensive' +
+      ' depth and inflict 30–40% degradation on David\'s Sling intercept capacity within' +
+      ' 10 days. Shipping insurance premiums in the Red Sea re-spike by 4–6x, adding economic' +
+      ' pressure on Europe. Risk: accelerates Israel\'s ground offensive into Lebanon, and' +
+      ' Hezbollah\'s resupply was already delayed 14–21 days per CIA/Mossad disruption (US' +
+      ' proxy-disrupt decision); proxy effectiveness degrades if resupply is cut.',
+    concurrencyRules: [
+      {
+        decisionId: 'seek-russian-chinese-mediation',
+        decisionTitle: 'Seek Russian/Chinese Mediation',
+        compatible: false,
+      },
+      {
+        decisionId: 'ballistic-strike-gulf-bases',
+        decisionTitle: 'Ballistic Missile Strike — Gulf Bases',
+        compatible: true,
+      },
+      {
+        decisionId: 'close-strait-hormuz',
+        decisionTitle: 'Close Strait of Hormuz',
+        compatible: true,
+      },
+      {
+        decisionId: 'nuclear-reconstitution',
+        decisionTitle: 'Accelerate Nuclear Reconstitution',
+        compatible: true,
+      },
+    ],
+  },
+}

--- a/lib/game/decisions/russia.ts
+++ b/lib/game/decisions/russia.ts
@@ -1,0 +1,343 @@
+// lib/game/decisions/russia.ts
+// Russia decision catalog for the Iran 2026 scenario.
+//
+// Strategic context (turn 115):
+//  - Russia is Iran's primary patron since the 2022 Ukraine war alignment.
+//  - Per WaPo (3 US officials) and corroborating CNN/NBC/AP sources, Russia is
+//    sharing US warship positions and satellite imagery with Iran.
+//  - Mojtaba Khamenei transported to Moscow on a Russian military plane ~March 16.
+//  - Russia benefits from oil price spikes (Urals crude ~$70+, well above its $59
+//    budget assumption, netting ~$150 M/day extra — research-economic.md §3).
+//  - Ukraine war limits bandwidth: Russia consumes the same weapons categories as
+//    Iran (SAMs, ballistic missiles, drones) — large-scale arms transfers are
+//    constrained (research-military.md §, research-economic.md §3).
+//  - BRICS/yuan de-dollarization narrative serves Russian geopolitical interests,
+//    but no single BRICS currency is imminent (research-economic.md §2).
+//
+// Source citations in strategicRationale reference the verified research files.
+import type { DecisionOption, DecisionDetail } from '@/lib/types/panels'
+
+export const RU_DECISIONS: DecisionOption[] = [
+  {
+    id: 'ru-arms-transfer-air-defense',
+    title: 'Arms Transfer — Air Defense Replenishment',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.45,
+    // No requiredAssets — Russia's leverage is political/economic/information
+  },
+  {
+    id: 'ru-unsc-veto',
+    title: 'UN Security Council Veto — Block Sanctions',
+    dimension: 'diplomatic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.2,
+  },
+  {
+    id: 'ru-mediation-offer',
+    title: 'Good Offices — Offer Mediation Platform',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.15,
+  },
+  {
+    id: 'ru-opec-production-cut',
+    title: 'OPEC+ Coordination — Production Cut',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.3,
+  },
+  {
+    id: 'ru-intel-pipeline',
+    title: 'Intel Pipeline — Share US Carrier Positions',
+    dimension: 'intelligence',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.5,
+  },
+  {
+    id: 'ru-disinfo-us-war-fatigue',
+    title: 'Disinfo Campaign — "Endless US War" Narrative',
+    dimension: 'information',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.25,
+  },
+]
+
+export const RU_DECISION_DETAILS: Record<string, DecisionDetail> = {
+  'ru-arms-transfer-air-defense': {
+    id: 'ru-arms-transfer-air-defense',
+    title: 'Arms Transfer — Air Defense Replenishment',
+    dimension: 'military',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.45,
+    strategicRationale:
+      "Iran's IADS was Israel's first target on both June 13, 2025, and February 28, 2026 " +
+      "(research-military.md §1, §10 — Trump claimed Iran had 'no air detection or radar'). " +
+      "Pre-existing contracts for S-400 components and confirmed Yak-130 / Mi-28 deliveries " +
+      "(research-military.md §3) establish a transfer channel via the Caspian Sea corridor. " +
+      "Replenishing short-range SAMs and EW modules extends the attrition dynamic, " +
+      "raising the cost of sustained US-Israeli air operations without committing Russian combat forces.",
+    expectedOutcomes:
+      "Partial restoration of Iranian point-defence coverage over Tehran and Fordow corridor " +
+      "within 4–6 weeks. Forces US to expend an additional estimated 80–120 Patriot/SM-6 " +
+      "interceptors per week to suppress newly emplaced systems. " +
+      "Russian defence-industrial exposure: moderate — transfers draw from stocks " +
+      "already strained by Ukraine (research-economic.md §3, research-military.md §3).",
+    concurrencyRules: [
+      {
+        decisionId: 'ru-unsc-veto',
+        decisionTitle: 'UN Security Council Veto — Block Sanctions',
+        compatible: true,
+        // Both obstruct US-led pressure; arms transfer + diplomatic cover reinforce each other
+      },
+      {
+        decisionId: 'ru-mediation-offer',
+        decisionTitle: 'Good Offices — Offer Mediation Platform',
+        compatible: false,
+        // Simultaneous peace-broker posture and active arms delivery is contradictory
+      },
+      {
+        decisionId: 'ru-intel-pipeline',
+        decisionTitle: 'Intel Pipeline — Share US Carrier Positions',
+        compatible: true,
+        // Both escalate Iran's defensive and offensive capacity; mutually reinforcing
+      },
+      {
+        decisionId: 'ru-opec-production-cut',
+        decisionTitle: 'OPEC+ Coordination — Production Cut',
+        compatible: true,
+        // Military support and economic pressure are orthogonal postures
+      },
+    ],
+  },
+
+  'ru-unsc-veto': {
+    id: 'ru-unsc-veto',
+    title: 'UN Security Council Veto — Block Sanctions',
+    dimension: 'diplomatic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.2,
+    strategicRationale:
+      "Russia holds a permanent UNSC veto and has exercised it consistently to shield Iran " +
+      "and Syria from multilateral sanctions. Iran's propaganda matrix explicitly cites " +
+      "'Russian and Chinese UNSC backing' as a legitimising frame (research-political.md §5). " +
+      "A veto on any new Iran sanctions resolution prevents the US from building the " +
+      "multilateral coercive coalition that accelerated Iraq/Libya capitulations, " +
+      "while signalling to Gulf states that Washington cannot weaponise the UN architecture.",
+    expectedOutcomes:
+      "Blocks any UNSC sanctions resolution with a single vote, requiring zero additional " +
+      "Russian resource commitment. US forced back to unilateral sanctions, which China and " +
+      "Gulf states will partially circumvent (research-economic.md §2). " +
+      "Reinforces the narrative — already circulating in MAGA circles — that US multilateral " +
+      "leadership is degraded (research-political.md §1, §4).",
+    concurrencyRules: [
+      {
+        decisionId: 'ru-arms-transfer-air-defense',
+        decisionTitle: 'Arms Transfer — Air Defense Replenishment',
+        compatible: true,
+        // Diplomatic obstruction and military support both block US pressure tracks
+      },
+      {
+        decisionId: 'ru-mediation-offer',
+        decisionTitle: 'Good Offices — Offer Mediation Platform',
+        compatible: true,
+        // Vetoing US-drafted sanctions while offering Russian mediation is classic
+        // "spoiler/honest-broker" dual posture; not logically contradictory
+      },
+      {
+        decisionId: 'ru-disinfo-us-war-fatigue',
+        decisionTitle: 'Disinfo Campaign — "Endless US War" Narrative',
+        compatible: true,
+        // UNSC veto generates news cycles that RT/Sputnik can amplify
+      },
+    ],
+  },
+
+  'ru-mediation-offer': {
+    id: 'ru-mediation-offer',
+    title: 'Good Offices — Offer Mediation Platform',
+    dimension: 'diplomatic',
+    escalationDirection: 'de-escalate',
+    resourceWeight: 0.15,
+    strategicRationale:
+      "Mojtaba Khamenei was transported to Moscow on a Russian military plane ~March 16 " +
+      "(research-political.md §2) — the clearest signal that Russia has unique access to " +
+      "Iran's de-facto leadership. Putin proposing Moscow or Sochi as a US-Iran negotiation " +
+      "venue positions Russia as indispensable interlocutor, mirroring the Oman model " +
+      "(research-political.md §4) while shifting diplomatic capital eastward. " +
+      "Success is not required — the mere offer generates leverage and a narrative of " +
+      "Russian statesmanship versus US unilateralism.",
+    expectedOutcomes:
+      "Even a rejected offer improves Russia's image in Global South and non-aligned states. " +
+      "If accepted, Moscow gains a treaty-signing venue comparable to the 1975 Helsinki Accords, " +
+      "boosting Putin's domestic legitimacy ahead of any post-Ukraine peace process. " +
+      "US domestic audience effect: amplifies Congressional voices calling for negotiated exit " +
+      "(research-political.md §1 — 65% of Americans say Trump has not explained war goals).",
+    concurrencyRules: [
+      {
+        decisionId: 'ru-arms-transfer-air-defense',
+        decisionTitle: 'Arms Transfer — Air Defense Replenishment',
+        compatible: false,
+        // Active weapons delivery while claiming peace-broker role destroys credibility
+      },
+      {
+        decisionId: 'ru-intel-pipeline',
+        decisionTitle: 'Intel Pipeline — Share US Carrier Positions',
+        compatible: false,
+        // Providing real-time US military targeting data while hosting peace talks
+        // would collapse any negotiations if revealed
+      },
+      {
+        decisionId: 'ru-opec-production-cut',
+        decisionTitle: 'OPEC+ Coordination — Production Cut',
+        compatible: true,
+        // Economic posture (oil price) and diplomatic posture are orthogonal
+      },
+      {
+        decisionId: 'ru-disinfo-us-war-fatigue',
+        decisionTitle: 'Disinfo Campaign — "Endless US War" Narrative',
+        compatible: false,
+        // Running US-war-fatigue propaganda while presenting as neutral mediator is
+        // contradictory; if surfaced it poisons the mediation channel
+      },
+    ],
+  },
+
+  'ru-opec-production-cut': {
+    id: 'ru-opec-production-cut',
+    title: 'OPEC+ Coordination — Production Cut',
+    dimension: 'economic',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.3,
+    strategicRationale:
+      "Russia's February 2026 oil revenue was at its weakest since the 2022 invasion " +
+      "— $9.5 B with Urals at ~$40/bbl — but the conflict has already pushed Urals " +
+      "above $70/bbl, netting Russia ~$150 M/day in additional revenue " +
+      "(research-economic.md §3). Coordinating with Saudi Arabia and UAE through " +
+      "OPEC+ to hold or deepen supply cuts keeps prices elevated above $100/bbl, " +
+      "maximising Russia's windfall while prolonging the US economic strain that " +
+      "Sen. Rand Paul (research-political.md §1) and the Consumer Sentiment collapse " +
+      "to 57.9 (research-economic.md §5) make politically damaging for the White House.",
+    expectedOutcomes:
+      "Each additional $10/bbl sustained above baseline generates ~$1.63 B/month for " +
+      "Russia (Carnegie Russia Eurasia Center, research-economic.md §3). " +
+      "Maintaining Brent above $110 through OPEC+ discipline could yield an additional " +
+      "~$30–50 B annually for the Russian budget, offsetting continued Ukraine war costs. " +
+      "Higher US gas prices (already at $3.79/gal, research-economic.md §5) compound " +
+      "midterm electoral pressure on Republicans (research-political.md §1).",
+    concurrencyRules: [
+      {
+        decisionId: 'ru-arms-transfer-air-defense',
+        decisionTitle: 'Arms Transfer — Air Defense Replenishment',
+        compatible: true,
+        // Economic and military support tracks are orthogonal
+      },
+      {
+        decisionId: 'ru-mediation-offer',
+        decisionTitle: 'Good Offices — Offer Mediation Platform',
+        compatible: true,
+        // Economic pressure and diplomatic posture are separable
+      },
+      {
+        decisionId: 'ru-disinfo-us-war-fatigue',
+        decisionTitle: 'Disinfo Campaign — "Endless US War" Narrative',
+        compatible: true,
+        // High gas prices provide real-world evidence for the "economic drain" narrative
+      },
+    ],
+  },
+
+  'ru-intel-pipeline': {
+    id: 'ru-intel-pipeline',
+    title: 'Intel Pipeline — Share US Carrier Positions',
+    dimension: 'intelligence',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.5,
+    strategicRationale:
+      "Washington Post (3 US officials), CNN (multiple sources), NBC (4 sources), and AP " +
+      "(2 officials) all independently confirmed on March 6, 2026 that Russia is sharing " +
+      "satellite imagery and real-time locations of American troops, ships, and aircraft " +
+      "with Iran (research-political.md §4, research-economic.md §3, research-military.md §6). " +
+      "The Kanopus-V / 'Khayyam' satellite provides continuous optical and radar coverage; " +
+      "by March 17 WSJ reported the sharing expanded to include improved drone guidance. " +
+      "Deepening this pipeline maximises Iran's ability to strike high-value targets while " +
+      "Russia maintains plausible deniability through 'technical cooperation' framing.",
+    expectedOutcomes:
+      "Iran's targeting accuracy against US carrier strike groups and air bases improves " +
+      "by an estimated 30–40% for stand-off weapons. Risk: if the US confirms the link " +
+      "publicly and imposes secondary sanctions on Russian energy exports, Russia loses " +
+      "part of its oil windfall. Counter-risk is bounded because the Trump administration " +
+      "has already issued a 30-day sanctions waiver on Russian oil (research-economic.md §3), " +
+      "signalling reluctance to escalate against Moscow.",
+    concurrencyRules: [
+      {
+        decisionId: 'ru-arms-transfer-air-defense',
+        decisionTitle: 'Arms Transfer — Air Defense Replenishment',
+        compatible: true,
+        // Intel sharing and arms delivery both enhance Iran's military capacity
+      },
+      {
+        decisionId: 'ru-mediation-offer',
+        decisionTitle: 'Good Offices — Offer Mediation Platform',
+        compatible: false,
+        // Active real-time targeting assistance is incompatible with peace-broker posture
+      },
+      {
+        decisionId: 'ru-disinfo-us-war-fatigue',
+        decisionTitle: 'Disinfo Campaign — "Endless US War" Narrative',
+        compatible: true,
+        // Intelligence pipeline and information operations serve parallel tracks
+      },
+    ],
+  },
+
+  'ru-disinfo-us-war-fatigue': {
+    id: 'ru-disinfo-us-war-fatigue',
+    title: 'Disinfo Campaign — "Endless US War" Narrative',
+    dimension: 'information',
+    escalationDirection: 'escalate',
+    resourceWeight: 0.25,
+    strategicRationale:
+      "The propaganda classification matrix (research-political.md §5) identifies " +
+      "'US war-of-choice for Israel' and 'imminent threat was fabricated' as the two " +
+      "most traction-gaining frames in US domestic discourse — validated by Kent's " +
+      "resignation letter, Tucker Carlson, MTG, and Rogan (research-political.md §1). " +
+      "RT and Sputnik — plus secondary amplification networks in MAGA-adjacent social " +
+      "media — can inject and amplify these narratives in US and European audiences " +
+      "at negligible cost, exploiting authentic MAGA fractures and 57.9-point " +
+      "consumer-sentiment collapse (research-economic.md §5).",
+    expectedOutcomes:
+      "Estimated 5–8 point additional decline in US public war support within 30 days " +
+      "if messaging aligns with authentic grievance cycles (gas prices, casualty counts, " +
+      "Rubio admission). Accelerates pressure on Republican House members in vulnerable " +
+      "seats — pre-war models already projected R losing ~28 seats (research-political.md §1). " +
+      "European audiences: amplifies 'US unilateralism' frame, complicating NATO burden-sharing " +
+      "asks and reducing allied willingness to backstop US munitions depletion.",
+    concurrencyRules: [
+      {
+        decisionId: 'ru-unsc-veto',
+        decisionTitle: 'UN Security Council Veto — Block Sanctions',
+        compatible: true,
+        // UNSC veto generates authentic news events that disinfo can amplify
+      },
+      {
+        decisionId: 'ru-mediation-offer',
+        decisionTitle: 'Good Offices — Offer Mediation Platform',
+        compatible: false,
+        // War-fatigue propaganda contradicts neutral-mediator persona
+      },
+      {
+        decisionId: 'ru-intel-pipeline',
+        decisionTitle: 'Intel Pipeline — Share US Carrier Positions',
+        compatible: true,
+        // Information operations and intelligence activities are parallel tracks
+      },
+      {
+        decisionId: 'ru-opec-production-cut',
+        decisionTitle: 'OPEC+ Coordination — Production Cut',
+        compatible: true,
+        // High gas prices provide material evidence for the economic-drain narrative
+      },
+    ],
+  },
+}

--- a/tests/game/turn-helpers.test.ts
+++ b/tests/game/turn-helpers.test.ts
@@ -136,8 +136,10 @@ describe('buildTurnPlanFromIds', () => {
   })
 
   it('throws if actor has no decisions in catalog', () => {
+    // All scenario actors (united_states, iran, israel, russia, china, gulf_states)
+    // now have non-empty catalogs. Use a synthetic actor id to exercise the guard.
     expect(() =>
-      buildTurnPlanFromIds('expand-air', [], 'iran', catalog),
+      buildTurnPlanFromIds('expand-air', [], 'made_up_actor', catalog),
     ).toThrow('No decisions')
   })
 })


### PR DESCRIPTION
## Why this PR exists

PRs #74, #75, #76, #77 each add one actor's decision catalog, and each modifies `lib/game/decisions/index.ts` to wire their actor into `DECISION_CATALOG` / `DECISION_DETAILS`. After #73 (Israel) merged, each of the remaining 4 conflicted on `index.ts` — you'd need to rebase, resolve, re-merge, rebase the next, etc.

This consolidates all 4 into a single PR with one clean `index.ts` update. Merge this, close #74–#77 as superseded.

## What's in it

4 new files (copied verbatim from the respective per-actor branches):
- `lib/game/decisions/iran.ts` — from PR #74 (`IR_DECISIONS`, 6 decisions, research-cited)
- `lib/game/decisions/russia.ts` — from PR #75 (`RU_DECISIONS`, 6 decisions)
- `lib/game/decisions/china.ts` — from PR #76 (`CN_DECISIONS`, 6 decisions)
- `lib/game/decisions/gulf-states.ts` — from PR #77 (`GCC_DECISIONS`, 6 decisions)

Modified:
- `lib/game/decisions/index.ts` — wires all 4 imports + populates both records
- `tests/game/turn-helpers.test.ts` — 'no decisions' test now uses a synthetic actor (all real actors now have catalogs)

## Verification
- `npm run typecheck` clean
- `npm run lint` clean
- `npm test -- --run tests/game/` — 16/16 + 1 passing

## After merge

Close PRs #74, #75, #76, #77 as superseded. Issue #52 auto-closes (this commit references "Closes #52").

Next turn submission will see all 6 AI actors generate plans. Realistically this means ~$1.00–$2.00 per turn now (6× actor agents + resolution + judge + narrator). Budget awareness from #58 becomes more urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)