### PR TITLE
fix(layout): wire favicon metadata to /favicon.svg

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,9 @@ export const metadata: Metadata = {
   title: "War Game — Strategic Simulation Engine",
   description:
     "AI-powered strategic war game simulation engine modeling competitive dynamics between actors through interactive decision-making and branching scenario trees.",
+  icons: {
+    icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

- Adds `icons` metadata to `app/layout.tsx` pointing to `/favicon.svg`
- Without this, browsers request the default `/favicon.ico` and get a 404 on every page load

This is the last remaining delta from the (now-obsolete) PR #59 that hadn't been picked up elsewhere. `public/favicon.svg` is already on `main`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new warnings)
- [x] `npm test -- --run` — 276 passed, 3 skipped
- [ ] Manual: load any page — no `/favicon.ico` 404 in devtools network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)