### PR TITLE
fix: graceful fallbacks for dev-mode map fetches

### DIFF
--- a/app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts
+++ b/app/api/scenarios/[id]/branches/[branchId]/map-assets/route.ts
@@ -85,8 +85,9 @@ export async function GET(
   const turnCommitId = searchParams.get('turnCommitId')
 
   // When no turnCommitId is provided (e.g. first load before any turn is committed),
-  // fall back to returning an empty asset set with a 200 so the map loads cleanly.
-  if (!turnCommitId) {
+  // or when a dev-mode synthetic ID is passed (e.g. "dev-commit-0"), fall back to
+  // returning an empty asset set with a 200 so the map loads cleanly.
+  if (!turnCommitId || turnCommitId.startsWith('dev-')) {
     return NextResponse.json({ data: { turn_commit_id: null, as_of_date: null, assets: [], shipping_lanes: [] } })
   }
 

--- a/app/api/scenarios/[id]/cities/route.ts
+++ b/app/api/scenarios/[id]/cities/route.ts
@@ -11,6 +11,12 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
     .select('*')
     .eq('scenario_id', scenarioId)
     .order('name')
+  // Degrade gracefully when the table isn't present in the current schema
+  // (e.g. migration not applied to this environment). The map renders fine
+  // without dynamic cities — static GeoJSON in MapboxMap provides the fallback.
+  if (error?.code === 'PGRST205') {
+    return NextResponse.json({ data: [] })
+  }
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json({ data })
 }


### PR DESCRIPTION
## Summary

Two 500s fire on first load of the `/play` page when running with `NEXT_PUBLIC_DEV_MODE=true`:

1. **map-assets**: UI generates synthetic \`turnCommitId\` like \`dev-commit-0\` for dev-mode forked branches. The route passed it straight to a UUID-typed column → \`invalid input syntax for type uuid\`. Now detects the \`dev-\` prefix and returns the same empty-response shape we already have for the null-ID case.

2. **cities**: Query 500s when \`city_registry\` isn't in the current Supabase schema cache (\`PGRST205\` — migration not applied to this project). The map already has static city GeoJSON in \`MapboxMap.tsx\`, so we now return an empty array for that specific error code instead of raising a banner.

## Verification

Confirmed end-to-end via Playwright against a dev-mode local server:

- `/` — landing page renders cleanly
- `/scenarios` — scenario browser works
- `/scenarios/:id` — actor hub, branch timeline, perspective selector all load
- `/scenarios/:id/play/:branchId` — map, layer controls, actor status, fog-of-war, escalation ticker, chronicle/events/actors tabs all render
- Previously-red banners ("ASSET FETCH FAILED") no longer appear

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (pre-existing MapboxMap warnings only)
- [x] `npm test -- --run` — 276 passed, 3 skipped
- [ ] Manual: load \`/play\` in dev mode and confirm no 500s in devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)